### PR TITLE
Use empty string as DM value for minimal+X11 and textmode (FATE#319432)

### DIFF
--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -238,7 +238,7 @@ textdomain="control"
                 <name>min_x</name>
                 <desktop>twm</desktop>
                 <label_id>desktop_min_x</label_id>
-                <logon>xdm</logon>
+                <logon></logon>
                 <cursor>DMZ</cursor>
                 <packages>xorg-x11-server branding-openSUSE</packages>
                 <order config:type="integer">6</order>
@@ -262,7 +262,7 @@ textdomain="control"
                 <name>textmode</name>
                 <desktop>twm</desktop>
                 <label_id>desktop_textmode</label_id>
-                <logon>xdm</logon>
+                <logon></logon>
                 <cursor>DMZ</cursor>
                 <packages>branding-openSUSE</packages>
                 <order config:type="integer">8</order>

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Sep 23 10:29:37 UTC 2015 - sndirsch@suse.com
+
+- use empty string as DISPLAYMANAGER for minimal+X11 and textmode
+  pattern, which on the system already results in chosing xdm as
+  default DM; this enables us to set displaymanager in %post of
+  the appropriated DM package (FATE#319432)
+
+-------------------------------------------------------------------
 Thu Apr 30 14:43:23 UTC 2015 - mlin@suse.com
 
 - Use Plasma 5 as default KDE environment


### PR DESCRIPTION
Use empty string as value for DISPLAYMANAGER for minimal+X11 and textmode
pattern, which on the system already results in chosing xdm as default DM.
This enables us to set displaymanager in %post of the appropriated DM package.