### PR TITLE
primary Server selection

### DIFF
--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -267,7 +267,7 @@ textdomain="control"
                 <packages>branding-openSUSE</packages>
                 <order config:type="integer">8</order>
                 <patterns>minimal_base minimal_base-conflicts</patterns>
-                <icon>yast-sshd</icon>
+                <icon>yast-ssh-server</icon>
             </one_supported_desktop>
 
         </supported_desktops>

--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -208,6 +208,18 @@ textdomain="control"
             </one_supported_desktop>
 
             <one_supported_desktop>
+                <name>server</name>
+                <desktop>icewm</desktop>
+                <label_id>desktop_server</label_id>
+                <logon>xdm</logon>
+                <cursor>DMZ</cursor>
+                <packages></packages>
+                <order config:type="integer">1</order>
+                <patterns>generic_server</patterns>
+                <icon>yast-ssh-server</icon>
+            </one_supported_desktop>
+
+            <one_supported_desktop>
                 <name>xfce</name>
                 <!-- BNC #667408 -->
                 <desktop>xfce</desktop>
@@ -385,6 +397,7 @@ is the most appropriate desktop for you.</label></desktop_dialog>
         <!-- Desktop dialog: desktop names -->
         <desktop_gnome><label>GNOME Desktop</label></desktop_gnome>
         <desktop_kde><label>KDE Desktop</label></desktop_kde>
+        <desktop_server><label>Server (Text Mode)</label></desktop_server>
         <desktop_xfce><label>XFCE Desktop</label></desktop_xfce>
         <desktop_lxde><label>LXDE Desktop</label></desktop_lxde>
         <desktop_min_x><label>Minimal X Window</label></desktop_min_x>


### PR DESCRIPTION
add server install into main selection
    
to give more visibility that openSUSE is not only for the Desktop

(note: this will probably need adaptions in openQA code and needles)

install size is 979MB on x86_64 (2015-10-02)
considerations:
This server pattern is not intended to be minimal, because it should be generally useful, which means we need to include things that will be used in some, but not all cases.


here is a (old) preview of how the result looks:
![server](https://cloud.githubusercontent.com/assets/637990/10142833/4dd897ee-6615-11e5-94f2-cab35db303dd.png)