### PR TITLE
openSUSE Leap 42.1 added to the list of products supported for upgrade by this product

### DIFF
--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -118,8 +118,10 @@ textdomain="control"
             <!-- openQA tests down to 12.1 -->
             <regexp_item>^openSUSE 12\..*</regexp_item>
             <regexp_item>^openSUSE 13\..*$</regexp_item>
-	    <!-- TW snapshots -->
+            <!-- TW snapshots -->
             <regexp_item>^openSUSE 20[0-9]*$</regexp_item>
+            <!-- Leap 42.1 milestones,betas,... -->
+            <regexp_item>^openSUSE Leap 42\.1.*$</regexp_item>
         </products_supported_for_upgrade>
 
         <!-- Bugzilla #327791, if not set, default is true -->

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Oct  5 09:05:33 CEST 2015 - locilka@suse.com
+
+- openSUSE Leap 42.1 added to the list of products supported for
+  upgrade by this product (bsc#947398)
+- 42.1.1
+
+-------------------------------------------------------------------
 Thu Oct  1 07:52:11 UTC 2015 - jreidinger@suse.com
 
 - sync partitioning settings with SLE (bsc#946891) by lnussel

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        42.1.0
+Version:        42.1.1
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT


### PR DESCRIPTION
- bsc#947398
- See also new test for these settings at https://github.com/yast/yast-update/pull/50