### PR TITLE
Fate#319624

### DIFF
--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -407,6 +407,11 @@ is the most appropriate desktop for you.</label></desktop_dialog>
                     <name>firewall_stage1</name>
                     <presentation_order>95</presentation_order>
                 </proposal_module>
+                <!-- Fate #319624 - proposal and dialog for existing SSH host keys -->
+                <proposal_module>
+                    <name>ssh_import</name>
+                    <presentation_order>97</presentation_order>
+                </proposal_module>
                 <proposal_module>
                     <name>clone</name>
                     <presentation_order>99</presentation_order>
@@ -461,6 +466,11 @@ is the most appropriate desktop for you.</label></desktop_dialog>
                 <proposal_module>
                     <name>firewall_stage1</name>
                     <presentation_order>99</presentation_order>
+                </proposal_module>
+                <!-- Fate #319624 - proposal and dialog for existing SSH host keys -->
+                <proposal_module>
+                    <name>ssh_import</name>
+                    <presentation_order>90</presentation_order>
                 </proposal_module>
             </proposal_modules>
         </proposal>

--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -54,44 +54,6 @@ textdomain="control"
             </save_instsys_item>
         </save_instsys_content>
 
-        <!-- FATE #305019: configure the files to copy from a previous installation -->
-        <copy_to_system config:type="list">
-            <!-- FATE #300421: Import ssh keys from previous installations -->
-            <copy_to_system_item>
-                <id>import_ssh_keys</id>
-                <copy_to_dir>/</copy_to_dir>
-                <!-- Files that must be all present on the previous system -->
-                <mandatory_files config:type="list">
-                    <file_item>/etc/ssh/ssh_host_key</file_item>
-                    <file_item>/etc/ssh/ssh_host_key.pub</file_item>
-                </mandatory_files>
-                <!-- Files thay may be present -->
-                <optional_files config:type="list">
-                    <file_item>/etc/ssh/ssh_host_dsa_key</file_item>
-                    <file_item>/etc/ssh/ssh_host_dsa_key.pub</file_item>
-                    <file_item>/etc/ssh/ssh_host_rsa_key</file_item>
-                    <file_item>/etc/ssh/ssh_host_rsa_key.pub</file_item>
-                    <file_item>/etc/ssh/ssh_host_ecdsa_key</file_item>
-                    <file_item>/etc/ssh/ssh_host_ecdsa_key.pub</file_item>
-                    <file_item>/etc/ssh/ssh_host_ed25519_key</file_item>
-                    <file_item>/etc/ssh/ssh_host_ed25519_key.pub</file_item>
-                </optional_files>
-            </copy_to_system_item>
-
-            <!-- FATE #120103: Import Users From Existing Partition -->
-            <copy_to_system_item>
-                <id>import_users</id>
-                <copy_to_dir>/var/lib/YaST2/imported/userdata/</copy_to_dir>
-                <!-- Files that must be all present on the previous system -->
-                <mandatory_files config:type="list">
-                    <file_item>/etc/shadow</file_item>
-                    <file_item>/etc/passwd</file_item>
-                    <file_item>/etc/login.defs</file_item>
-                    <file_item>/etc/group</file_item>
-                </mandatory_files>
-            </copy_to_system_item>
-        </copy_to_system>
-
         <!-- FATE #303395, Kexec instead of reboot (default 'false') -->
         <kexec_reboot config:type="boolean">true</kexec_reboot>
 

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon May 16 18:44:49 UTC 2016 - ancor@suse.com
+
+- Removed not longer necessary items from copy_to_system section
+- Added SSH keys import section to the proposal
+- Fate#319624 
+- 13.2.28
+
+-------------------------------------------------------------------
 Thu Apr 14 08:36:07 UTC 2016 - lnussel@suse.de
 
 - Remove vm_keep_unpartitioned_region

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        13.2.27
+Version:        13.2.28
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT


### PR DESCRIPTION
- Added SSH keys import section to the proposal. See https://github.com/yast/yast-installation/pull/374
- Remove not longer necessary items from the `copy_to_system` section
  - SSH host keys no longer necessary. See https://build.opensuse.org/request/show/396066
  - Users database not longer necessary for user import. See https://build.opensuse.org/request/show/393918