### PR TITLE
Include the Ruby debugger (byebug) in the inst-sys (FATE#318421)

### DIFF
--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu May 19 08:56:56 UTC 2016 - lslezak@suse.cz
+
+- Include the Ruby debugger (byebug) in the inst-sys for easier
+  YaST debugging (FATE#318421)
+- 13.2.29
+
+-------------------------------------------------------------------
 Mon May 16 18:44:49 UTC 2016 - ancor@suse.com
 
 - Removed not longer necessary items from copy_to_system section

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        13.2.28
+Version:        13.2.29
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT
@@ -72,6 +72,9 @@ Requires:       yast2-tune
 Requires:       yast2-update
 Requires:       yast2-users
 Requires:       yast2-x11
+# Ruby debugger in the inst-sys (FATE#318421)
+Requires:       rubygem(%{rb_default_ruby_abi}:byebug)
+
 Conflicts:      product_control
 Provides:       product_control
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
- 13.2.29

Note: We need to add the debugger package via this skelcd-control package dependency, dependency in an YaST package would add it also in the installed system which we do not want by default.

Note2: The same change will follow in the SLES/SLED skelcd packages.