### PR TITLE
Remove dependency on yast2-qt-branding-openSUSE

### DIFF
--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon May 30 12:32:36 UTC 2016 - fvogt@suse.com
+
+- Remove dependency on yast2-qt-branding-openSUSE (boo#955381)
+- 13.2.31
+
+-------------------------------------------------------------------
 Wed May 25 13:44:29 CEST 2016 - schubi@suse.de
 
 - Cloning ssh_import settings for AutoYaST (FATE#319624).

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -62,8 +62,6 @@ Requires:       yast2-network >= 3.1.24
 Requires:       yast2-nfs-client
 Requires:       yast2-ntp-client
 Requires:       yast2-proxy
-# this is the default theme
-Requires:       yast2-qt-branding-openSUSE
 Requires:       yast2-services-manager
 Requires:       yast2-slp
 Requires:       yast2-theme-openSUSE-Oxygen


### PR DESCRIPTION
See https://bugzilla.suse.com/show_bug.cgi?id=955381 for reasons why that package should be removed.

This seems to be the only reference to that package, AFAICS it's not necessary anymore, but I might be wrong.