### PR TITLE
Inst-sys clean up (bsc#974601)

### DIFF
--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -698,6 +698,14 @@ TODO: prepare disk here when it does not break space calculation (and remove bel
                     <label>Perform Installation</label>
                     <name>prepdisk</name>
                 </module>
+                <!-- Clean up the inst-sys to have more free RAM on low memory systems -->
+                <!-- Note: Needs to be call *after* the partitioning step as it might delete
+                the file system or storage kernel modules from inst-sys. They need to be already
+                loaded and active. -->
+                <module>
+                    <label>Installer Cleanup</label>
+                    <name>instsys_cleanup</name>
+                </module>
                 <!-- Installation from images -->
                 <module>
                     <label>Perform Installation</label>
@@ -900,6 +908,14 @@ TODO: prepare disk here when it does not break space calculation (and remove bel
                     <label>Perform Update</label>
                     <name>prepdisk</name>
                 </module>
+                <!-- Clean up the inst-sys to have more free RAM on low memory systems -->
+                <!-- Note: Needs to be call *after* the partitioning step as it might delete
+                the file system or storage kernel modules from inst-sys. They need to be already
+                loaded and active. -->
+                <module>
+                    <label>Installer Cleanup</label>
+                    <name>instsys_cleanup</name>
+                </module>
                 <module>
                     <label>Perform Update</label>
                     <name>kickoff</name>
@@ -987,6 +1003,14 @@ TODO: prepare disk here when it does not break space calculation (and remove bel
                     <label>Perform Installation</label>
                     <name>prepdisk</name>
                 </module>
+                <!-- Clean up the inst-sys to have more free RAM on low memory systems -->
+                <!-- Note: Needs to be call *after* the partitioning step as it might delete
+                the file system or storage kernel modules from inst-sys. They need to be already
+                loaded and active. -->
+                <module>
+                    <label>Installer Cleanup</label>
+                    <name>instsys_cleanup</name>
+                </module>
                 <module>
                 <label>Perform Installation</label>
                     <name>deploy_image</name>
@@ -1073,6 +1097,14 @@ TODO: prepare disk here when it does not break space calculation (and remove bel
                 <module>
                     <label>Perform Update</label>
                     <name>prepdisk</name>
+                </module>
+                <!-- Clean up the inst-sys to have more free RAM on low memory systems -->
+                <!-- Note: Needs to be call *after* the partitioning step as it might delete
+                the file system or storage kernel modules from inst-sys. They need to be already
+                loaded and active. -->
+                <module>
+                    <label>Installer Cleanup</label>
+                    <name>instsys_cleanup</name>
                 </module>
                 <module>
                     <label>Perform Update</label>

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jul 21 11:30:11 UTC 2016 - lslezak@suse.cz
+
+- Remove some files from the inst-sys to have more free RAM on low
+  memory systems (bsc#974601)
+- 42.2.0
+
+-------------------------------------------------------------------
 Tue Jun 14 15:42:12 UTC 2016 - igonzalezsosa@suse.com
 
 - Delay self-update during autoupgrade until software manager

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        13.2.31
+Version:        42.2.0
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT
@@ -55,6 +55,8 @@ Requires:       yast2-add-on
 Requires:       yast2-fcoe-client
 # For creating the AutoYast profile at the end of installation (bnc#887406)
 Requires:       yast2-firewall
+# instsys_cleanup
+Requires:       yast2-installation >= 3.1.201
 Requires:       yast2-iscsi-client
 Requires:       yast2-kdump
 Requires:       yast2-multipath


### PR DESCRIPTION
Remove some files from the inst-sys to have more free RAM on low memory systems.

This PR activates the cleaner (https://github.com/yast/yast-installation/pull/407) in the installation/upgrade workflow.

- Version updated to 42.2.0 (to match Leap 42.2, it seems we forgot to bump the minor since openSUSE 13.2...)

The cleaner is called at the initial stage when the inst-sys is running in memory:

- Initial installation
- Upgrade
- Autoinstallation
- Autoupgrade