### PR TITLE
Move self-update client to the beginning

### DIFF
--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -601,6 +601,11 @@ is the most appropriate desktop for you.</label></desktop_dialog>
                     <label>Network Autosetup</label>
                     <name>setup_dhcp</name>
                 </module>
+                <!-- As soon as possible but after network is initialized -->
+                <module>
+                    <label>Installer Update</label>
+                    <name>update_installer</name>
+                </module>
                 <module>
                     <label>Welcome</label>
                     <name>complex_welcome</name>
@@ -622,13 +627,6 @@ is the most appropriate desktop for you.</label></desktop_dialog>
                 <module>
                     <label>System Analysis</label>
                     <name>system_analysis</name>
-                </module>
-                <!-- As soon as possible but after packager is initialized -->
-                <module>
-                    <label>Installer Update</label>
-                    <name>update_installer</name>
-                    <enable_back>yes</enable_back>
-                    <enable_next>yes</enable_next>
                 </module>
                 <module>
                     <label>System Analysis</label>
@@ -849,6 +847,19 @@ TODO: prepare disk here when it does not break space calculation (and remove bel
             <stage>initial</stage>
             <modules config:type="list">
                 <module>
+                    <label>Load linuxrc Network Configuration</label>
+                    <name>install_inf</name>
+                </module>
+                <module>
+                    <label>Network Autosetup</label>
+                    <name>setup_dhcp</name>
+                </module>
+                <!-- As soon as possible but after network is initialized -->
+                <module>
+                    <label>Installer Update</label>
+                    <name>update_installer</name>
+                </module>
+                <module>
                     <name>complex_welcome</name>
                     <label>Welcome</label>
                     <enable_back>no</enable_back>
@@ -864,13 +875,6 @@ TODO: prepare disk here when it does not break space calculation (and remove bel
                 <module>
                     <label>System Analysis</label>
                     <name>system_analysis</name>
-                </module>
-                <!-- As soon as possible but after packager is initialized -->
-                <module>
-                    <label>Installer Update</label>
-                    <name>update_installer</name>
-                    <enable_back>yes</enable_back>
-                    <enable_next>yes</enable_next>
                 </module>
                 <module>
                     <label>System for Update</label>
@@ -975,18 +979,18 @@ TODO: prepare disk here when it does not break space calculation (and remove bel
                 <enable_next>no</enable_next>
             </defaults>
             <modules config:type="list">
+                <!-- As soon as possible -->
+                <module>
+                    <label>Installer Update</label>
+                    <name>update_installer</name>
+                    <enable_back>no</enable_back>
+                    <enable_next>yes</enable_next>
+                </module>
                 <module>
                     <label>AutoYaST Settings</label>
                     <name>autoinit</name>
                     <archs>all</archs>
                     <retranslate config:type="boolean">true</retranslate>
-                </module>
-                <!-- As soon as possible but after packager is initialized -->
-                <module>
-                    <label>Installer Update</label>
-                    <name>update_installer</name>
-                    <enable_back>yes</enable_back>
-                    <enable_next>yes</enable_next>
                 </module>
                 <module>
                     <label>AutoYaST Settings</label>
@@ -1049,6 +1053,13 @@ TODO: prepare disk here when it does not break space calculation (and remove bel
             <mode>autoupgrade</mode>
             <stage>initial</stage>
             <modules config:type="list">
+                <!-- As soon as possible -->
+                <module>
+                    <label>Installer Update</label>
+                    <name>update_installer</name>
+                    <enable_back>no</enable_back>
+                    <enable_next>yes</enable_next>
+                </module>
                 <module>
                     <label>System Analysis</label>
                     <name>system_analysis</name>
@@ -1066,13 +1077,6 @@ TODO: prepare disk here when it does not break space calculation (and remove bel
                     <name>autoinit</name>
                     <archs>all</archs>
                     <retranslate config:type="boolean">true</retranslate>
-                </module>
-                <!-- As soon as possible but after packager is initialized -->
-                <module>
-                    <label>Installer Update</label>
-                    <name>update_installer</name>
-                    <enable_back>yes</enable_back>
-                    <enable_next>yes</enable_next>
                 </module>
                 <module>
                     <label>AutoYaST Settings</label>

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,11 +1,17 @@
 -------------------------------------------------------------------
+Fri Aug 26 12:45:20 UTC 2016 - igonzalezsosa@suse.com
+
+- Move the YaST self update step earlier in the workflow to avoid
+  bugs caused by restarting YaST (boo#995771)
+- 42.2.3
+
+-------------------------------------------------------------------
 Thu Aug 25 13:50:17 UTC 2016 - lnussel@suse.de
 
 - Remove LXDE from desktop selection
 - Remove Enlightenment from desktop selection
 - Remove Textmode
 - KDE is default so put it first
-- 42.2.3
 
 -------------------------------------------------------------------
 Mon Aug  8 12:34:57 UTC 2016 - lnussel@suse.de


### PR DESCRIPTION
Version bump is not needed now because last update was rejected: https://ci.opensuse.org/job/yast-skelcd-control-openSUSE-openSUSE-42_2/5/

Currently we have a versions conflict with `master` that we need to discuss and address.