### PR TITLE
Remove debug-non-oss and debug-update-non-oss

### DIFF
--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -142,27 +142,9 @@ textdomain="control"
                 <priority config:type="integer">99</priority>
             </extra_url>
             <extra_url>
-                <baseurl>http://download.opensuse.org/debug/distribution/leap/42.2/repo/non-oss/</baseurl>
-                <alias>repo-debug-non-oss</alias>
-                <name>openSUSE-Leap-42.2-Debug-Non-Oss</name>
-                <prod_dir>/</prod_dir>
-                <enabled config:type="boolean">false</enabled>
-                <autorefresh config:type="boolean">true</autorefresh>
-                <priority config:type="integer">99</priority>
-            </extra_url>
-            <extra_url>
                 <baseurl>http://download.opensuse.org/debug/update/leap/42.2/oss</baseurl>
                 <alias>repo-debug-update</alias>
                 <name>openSUSE-Leap-42.2-Update-Debug</name>
-                <prod_dir>/</prod_dir>
-                <enabled config:type="boolean">false</enabled>
-                <autorefresh config:type="boolean">true</autorefresh>
-                <priority config:type="integer">99</priority>
-            </extra_url>
-            <extra_url>
-                <baseurl>http://download.opensuse.org/debug/update/leap/42.2/non-oss/</baseurl>
-                <alias>repo-debug-update-non-oss</alias>
-                <name>openSUSE-Leap-42.2-Update-Debug-Non-Oss</name>
                 <prod_dir>/</prod_dir>
                 <enabled config:type="boolean">false</enabled>
                 <autorefresh config:type="boolean">true</autorefresh>


### PR DESCRIPTION
These repositories don't exist.
Leap 42.1 has the same problem but it's too late for it.
