### PR TITLE
Drop live CD config

### DIFF
--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -464,24 +464,6 @@ is the most appropriate desktop for you.</label></desktop_dialog>
         </proposal>
 
         <proposal>
-            <label>Live Installation Settings</label>
-            <mode>live_installation</mode>
-            <stage>initial</stage>
-            <name>initial</name>
-            <unique_id>live_inst_initial</unique_id>
-            <enable_skip>no</enable_skip>
-            <proposal_modules config:type="list">
-                <proposal_module>hwinfo</proposal_module>
-                <proposal_module>partitions</proposal_module>
-                <proposal_module>bootloader</proposal_module>
-                <proposal_module>country_simple</proposal_module>
-                <proposal_module>timezone</proposal_module>
-                <proposal_module>users</proposal_module>
-                <proposal_module>default_target</proposal_module>
-            </proposal_modules>
-        </proposal>
-
-        <proposal>
             <label>Update Settings</label>
             <mode>update</mode>
             <name>initial</name>
@@ -729,93 +711,6 @@ TODO: prepare disk here when it does not break space calculation (and remove bel
             </modules>
         </workflow>
 
-        <!-- Stage: Initial, Mode: Live Installation -->
-        <workflow>
-            <defaults>
-                <archs>all</archs>
-                <enable_back>yes</enable_back>
-                <enable_next>yes</enable_next>
-            </defaults>
-            <label>Installation</label>
-            <mode>live_installation</mode>
-            <stage>initial</stage>
-            <modules config:type="list">
-               <module>
-                    <label>Load linuxrc Network Configuration</label>
-                    <name>install_inf</name>
-                </module>
-                <module>
-                    <label>Network Autosetup</label>
-                    <name>setup_dhcp</name>
-                </module>
-                <module>
-                    <label>Welcome</label>
-                    <name>complex_welcome</name>
-                    <enable_back>no</enable_back>
-                    <enable_next>yes</enable_next>
-                    <arguments>
-                        <first_run>yes</first_run>
-                    </arguments>
-                    <retranslate config:type="boolean">true</retranslate>
-                </module>
-                <module>
-                    <label>Time Zone</label>
-                    <name>timezone</name>
-                    <arguments>
-                        <first_run>yes</first_run>
-                    </arguments>
-                    <enable_back>yes</enable_back>
-                </module>
-                <module>
-                    <label>Disk</label>
-                    <name>disk_proposal</name>
-                    <enable_back>yes</enable_back>
-                    <enable_next>yes</enable_next>
-                </module>
-                <module>
-                    <label>User Settings</label>
-                    <name>user_first</name>
-                </module>
-                <module>
-                    <label>User Settings</label>
-                    <name>root_first</name>
-                </module>
-                <module>
-                    <label>Installation Settings</label>
-                    <name>inst_live_pre-proposal</name>
-                </module>
-                <module>
-                    <label>Installation Settings</label>
-                    <name>inst_proposal</name>
-                    <proposal>initial</proposal>
-                </module>
-                <!-- FATE #303860: Provide consistent progress during installation -->
-                <module>
-                    <label>Perform Installation</label>
-                    <name>prepareprogress</name>
-                </module>
-                <module>
-                    <label>Perform Installation</label>
-                    <name>inst_prepdisk</name>
-                </module>
-                <module>
-                    <label>Perform Installation</label>
-                    <name>inst_kickoff</name>
-                </module>
-                <module>
-                    <label>Perform Installation</label>
-                    <name>inst_live_doit</name>
-                    <enable_next>no</enable_next>
-                    <enable_back>no</enable_back>
-                </module>
-                <module>
-                    <label>Perform Installation</label>
-                    <name>inst_finish</name>
-                    <enable_back>no</enable_back>
-                </module>
-            </modules>
-        </workflow>
-
         <!-- Stage: Initial, Mode: Update -->
         <workflow>
             <defaults>
@@ -925,29 +820,6 @@ TODO: prepare disk here when it does not break space calculation (and remove bel
             </modules>
         </workflow>
 
-
-        <!-- TODO FIXME: fix the live installer to not require the 2nd stage -->
-        <!-- Stage: Continue, Mode: Live Installation -->
-        <workflow>
-            <stage>continue</stage>
-            <mode>live_installation</mode>
-            <defaults>
-                <enable_back>yes</enable_back>
-                <enable_next>yes</enable_next>
-                <archs>all</archs>
-            </defaults>
-            <modules config:type="list">
-                <module>
-                    <heading>yes</heading>
-                    <label>Configuration</label>
-                </module>
-                <module>
-                    <name>live_cleanup</name>
-                    <enable_back>no</enable_back>
-                </module>
-
-            </modules>
-        </workflow>
 
         <!-- Stage: Initial, Mode: AutoInstallation -->
         <workflow>

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Sep  8 12:24:32 UTC 2016 - lslezak@suse.cz
+
+- Cleanup: remove the LiveCD configuration, the yast2-live-installer
+  package was dropped in Tumbleweed (bsc#997829)
+- 42.2.99.1
+
+-------------------------------------------------------------------
 Fri Aug 26 12:45:20 UTC 2016 - igonzalezsosa@suse.com
 
 -  Move the YaST self update step earlier in the workflow to avoid

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        42.2.4
+Version:        42.2.99.1
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT


### PR DESCRIPTION
- Removed obsolete parts related to the Live CD installation, the `yast2-live-installer` package has been  dropped in Tumbleweed 
- Switch the versioning schema to `42.2.99.x` to not conflict with openSUSE-42.2 (`42.2.x`)
- The change is related to this PR: https://github.com/yast/yast-live-installer/pull/12