### PR TITLE
Revert "Improve the Travis check"

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -1,0 +1,10 @@
+#! /bin/bash
+
+set -e -x
+
+make -C control check
+
+# the "yast-travis-ruby" script is included in the base yastdevel/ruby image
+# see https://github.com/yast/docker-yast-ruby/blob/master/yast-travis-ruby
+yast-travis-ruby
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,4 @@ services:
 before_install:
   - docker build -t yast-skelcd-control-opensuse-image .
 script:
-  # the "yast-travis-ruby" script is included in the base yastdevel/ruby image
-  # see https://github.com/yast/docker-yast-ruby/blob/master/yast-travis-ruby
-  - docker run -it -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-skelcd-control-opensuse-image yast-travis-ruby
+  - docker run -it -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-skelcd-control-opensuse-image ./.travis.sh

--- a/Rakefile
+++ b/Rakefile
@@ -16,7 +16,3 @@ end
 # generate the *-promo files when creating the tarball
 task :tarball => :create_promo
 
-# check also the syntax of the XML files
-task :"check:syntax" do
-  sh "make -C control check"
-end


### PR DESCRIPTION
This reverts commit 89f74dd0a42fe590767b0864cede1bef309f10c2 (from PR #71).

The rake check:syntax is also called at Jenkins, it does not work there and breaks the package submission.