### PR TITLE
Select no default desktop on the selection list

### DIFF
--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -397,6 +397,7 @@ textdomain="control"
         <software>
           <default_desktop>kde</default_desktop>
         </software>
+	<no_default config:type="boolean">true</no_default>
       </system_role>
 
       <system_role>

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Apr 18 14:48:28 UTC 2017 - tchvatal@suse.com
+
+- In desktop selector keep all choices unselected for user to decide
+  (poo#14936, bsc#1025415)
+- 42.3.99.3
+
+-------------------------------------------------------------------
 Wed Feb  8 14:50:06 UTC 2017 - jreidinger@suse.com
 
 - add new desktop selection workflow (poo#14936, bsc#1025415)

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        42.3.99.2
+Version:        42.3.99.3
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT


### PR DESCRIPTION
Users will be required to click something to get desktop.

Follows up on "Adjusting desktop defaults to reflect project realities" thread on opensuse-factory mailing list (not archived yet).