### PR TITLE
Replace the generic_server pattern reference with console.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.pot
 package/*.tar.bz2
+.yardoc
+doc

--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -181,7 +181,7 @@ textdomain="control"
                 <cursor>DMZ</cursor>
                 <packages></packages>
                 <order config:type="integer">1</order>
-                <patterns>generic_server</patterns>
+                <patterns>console</patterns>
                 <icon>yast-ssh-server</icon>
             </one_supported_desktop>
 

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue May  9 07:23:50 UTC 2017 - sflees@suse.de
+
+- Replace the generic_server pattern reference with console.
+  * As part of the patterns cleanup the generic_server pattern 
+    was merged into the console pattern and removed.
+- 42.2.99.2
+
+-------------------------------------------------------------------
 Thu Sep  8 12:24:32 UTC 2016 - lslezak@suse.cz
 
 - Cleanup: remove the LiveCD configuration, the yast2-live-installer

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        42.2.99.1
+Version:        42.2.99.2
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT


### PR DESCRIPTION
As part of the patterns cleanup the generic_server pattern was merged into the console pattern and removed.