### PR TITLE
Added the new TW identification (bsc#1039193)

### DIFF
--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -84,8 +84,10 @@ textdomain="control"
             <regexp_item>^openSUSE 13\..*$</regexp_item>
             <!-- Updating from openSUSE Leap 42.x -->
             <regexp_item>^openSUSE Leap 42\..*$</regexp_item>
-	    <!-- TW snapshots -->
+            <!-- old TW snapshots -->
             <regexp_item>^openSUSE 20[0-9]*$</regexp_item>
+            <!-- new TW snapshots -->
+            <regexp_item>^openSUSE Tumbleweed$</regexp_item>
         </products_supported_for_upgrade>
 
         <!-- Bugzilla #327791, if not set, default is true -->

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed May 17 12:44:48 UTC 2017 - lslezak@suse.cz
+
+- Added the new TW identification to the list of the products
+  supported for upgrade (bsc#1039193)
+- 42.3.99.5
+
+-------------------------------------------------------------------
 Tue May  9 07:23:50 UTC 2017 - sflees@suse.de
 
 - Replace the generic_server pattern reference with console.

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        42.3.99.4
+Version:        42.3.99.5
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT


### PR DESCRIPTION
I have tested TW upgrade locally, this is what I found in the logs:

```
modules/Update.rb:250 Processing 'openSUSE Tumbleweed' from '/mnt'
modules/Update.rb:138 A regexp matches the installed product: false
clients/update_proposal.rb:468 Upgrade is not supported
```

- Added the new TW identification to the list of the products supported for upgrade  ([bsc#1039193](https://bugzilla.suse.com/show_bug.cgi?id=1039193))
- 42.3.99.5
