### PR TITLE
Re-add section for Live installation (boo#1042559)

### DIFF
--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -705,6 +705,24 @@ Firefox as browser, and Nautilus as file manager.
         </proposal>
 
         <proposal>
+            <label>Live Installation Settings</label>
+            <mode>live_installation</mode>
+            <stage>initial</stage>
+            <name>initial</name>
+            <unique_id>live_inst_initial</unique_id>
+            <enable_skip>no</enable_skip>
+            <proposal_modules config:type="list">
+                <proposal_module>hwinfo</proposal_module>
+                <proposal_module>partitions</proposal_module>
+                <proposal_module>bootloader</proposal_module>
+                <proposal_module>country_simple</proposal_module>
+                <proposal_module>timezone</proposal_module>
+                <proposal_module>users</proposal_module>
+                <proposal_module>default_target</proposal_module>
+            </proposal_modules>
+        </proposal>
+
+        <proposal>
             <label>Update Settings</label>
             <mode>update</mode>
             <name>initial</name>
@@ -969,6 +987,93 @@ TODO: prepare disk here when it does not break space calculation (and remove bel
             </modules>
         </workflow>
 
+        <!-- Stage: Initial, Mode: Live Installation -->
+        <workflow>
+            <defaults>
+                <archs>all</archs>
+                <enable_back>yes</enable_back>
+                <enable_next>yes</enable_next>
+            </defaults>
+            <label>Installation</label>
+            <mode>live_installation</mode>
+            <stage>initial</stage>
+            <modules config:type="list">
+               <module>
+                    <label>Load linuxrc Network Configuration</label>
+                    <name>install_inf</name>
+                </module>
+                <module>
+                    <label>Network Autosetup</label>
+                    <name>setup_dhcp</name>
+                </module>
+                <module>
+                    <label>Welcome</label>
+                    <name>complex_welcome</name>
+                    <enable_back>no</enable_back>
+                    <enable_next>yes</enable_next>
+                    <arguments>
+                        <first_run>yes</first_run>
+                    </arguments>
+                    <retranslate config:type="boolean">true</retranslate>
+                </module>
+                <module>
+                    <label>Time Zone</label>
+                    <name>timezone</name>
+                    <arguments>
+                        <first_run>yes</first_run>
+                    </arguments>
+                    <enable_back>yes</enable_back>
+                </module>
+                <module>
+                    <label>Disk</label>
+                    <name>disk_proposal</name>
+                    <enable_back>yes</enable_back>
+                    <enable_next>yes</enable_next>
+                </module>
+                <module>
+                    <label>User Settings</label>
+                    <name>user_first</name>
+                </module>
+                <module>
+                    <label>User Settings</label>
+                    <name>root_first</name>
+                </module>
+                <module>
+                    <label>Installation Settings</label>
+                    <name>inst_live_pre-proposal</name>
+                </module>
+                <module>
+                    <label>Installation Settings</label>
+                    <name>inst_proposal</name>
+                    <proposal>initial</proposal>
+                </module>
+                <!-- FATE #303860: Provide consistent progress during installation -->
+                <module>
+                    <label>Perform Installation</label>
+                    <name>prepareprogress</name>
+                </module>
+                <module>
+                    <label>Perform Installation</label>
+                    <name>inst_prepdisk</name>
+                </module>
+                <module>
+                    <label>Perform Installation</label>
+                    <name>inst_kickoff</name>
+                </module>
+                <module>
+                    <label>Perform Installation</label>
+                    <name>inst_live_doit</name>
+                    <enable_next>no</enable_next>
+                    <enable_back>no</enable_back>
+                </module>
+                <module>
+                    <label>Perform Installation</label>
+                    <name>inst_finish</name>
+                    <enable_back>no</enable_back>
+                </module>
+            </modules>
+        </workflow>
+
         <!-- Stage: Initial, Mode: Update -->
         <workflow>
             <defaults>
@@ -1078,6 +1183,26 @@ TODO: prepare disk here when it does not break space calculation (and remove bel
             </modules>
         </workflow>
 
+        <!-- Stage: Continue, Mode: Live Installation -->
+        <workflow>
+            <stage>continue</stage>
+            <mode>live_installation</mode>
+            <defaults>
+                <enable_back>yes</enable_back>
+                <enable_next>yes</enable_next>
+                <archs>all</archs>
+            </defaults>
+            <modules config:type="list">
+                <module>
+                    <heading>yes</heading>
+                    <label>Configuration</label>
+                </module>
+                <module>
+                    <name>live_cleanup</name>
+                    <enable_back>no</enable_back>
+                </module>
+            </modules>
+        </workflow>
 
         <!-- Stage: Initial, Mode: AutoInstallation -->
         <workflow>

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Sat Jun 17 11:58:16 UTC 2017 - opensuse.lietuviu.kalba@gmail.com
+
+- re-add sections section for LiveCD/LiveUSB installation for 
+  openSUSE Leap 42.3 (boo#1042559)
+- 42.3.3
+
+-------------------------------------------------------------------
 Wed Feb  8 14:50:06 UTC 2017 - jreidinger@suse.com
 
 - add new desktop selection workflow (poo#14936, bsc#1025415)

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        42.3.2
+Version:        42.3.3
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT


### PR DESCRIPTION
yast2-live-installer package has been dropped in Tumbleweed, but it is still provided in openSUSE Leap and needs sections for Live installation