### PR TITLE
/var/lib/ceph as btrfs subvolume with CoW disabled (bsc#1013011)

### DIFF
--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -321,6 +321,10 @@ textdomain="control"
             <subvolume>
                 <path>var/crash</path>
             </subvolume>
+	    <subvolume>
+		<path>var/lib/ceph</path>
+		<copy_on_write config:type="boolean">false</copy_on_write>
+	    </subvolume>
             <subvolume>
                 <path>var/lib/libvirt/images</path>
                 <copy_on_write config:type="boolean">false</copy_on_write>

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Dec  7 18:55:07 UTC 2017 - kmroz@suse.com
+
+- /var/lib/ceph as btrfs subvolume with CoW disabled (bsc#1013011)
+- 42.3.99.17
+
+-------------------------------------------------------------------
 Fri Dec  1 12:21:48 UTC 2017 - dimstar@opensuse.org
 
 - In case prjconf defines skelcd_compat, do not yet move skelcdpath

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        42.3.99.16
+Version:        42.3.99.17
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT


### PR DESCRIPTION
Signed-off-by: Karol Mroz <kmroz@suse.de>