### PR TITLE
Fix build error on non-x86

### DIFF
--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -132,7 +132,7 @@ install -m 644 control/${CONTROL_FILE} $RPM_BUILD_ROOT%{?skelcdpath}/CD1/control
     sed -i -e "s,http://download.opensuse.org/source/,http://download.opensuse.org/ports/$ports_arch/source/," %{buildroot}%{?skelcdpath}/CD1/control.xml
     sed -i -e "s,http://download.opensuse.org/update/tumbleweed/,http://download.opensuse.org/ports/$ports_arch/update/tumbleweed/," %{buildroot}%{?skelcdpath}/CD1/control.xml
     #we parse out non existing non-oss repo for ports
-    xsltproc -o %{buildroot}%{?skelcdpath}/CD1/control.xml control/nonoss.xsl %{buildroot}%{?skelcdpath}/CD1/control.xml/
+    xsltproc -o %{buildroot}%{?skelcdpath}/CD1/control_ports.xml control/nonoss.xsl %{buildroot}%{?skelcdpath}/CD1/control.xml/
     mv %{buildroot}%{?skelcdpath}/CD1/control{_ports,}.xml
     xmllint --noout --relaxng %{_datadir}/YaST2/control/control.rng %{buildroot}%{?skelcdpath}/CD1/control.xml
 %endif


### PR DESCRIPTION
The following line was trying to mv the _ports file back, so
we need to write it under the temporary name