### PR TITLE
Change xsltproc parms in spec to avoid PowerPC build error

### DIFF
--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Jan 22 16:30:06 UTC 2018 - normand@linux.vnet.ibm.com
+
+- in spec file change xsltproc parms to avoid PowerPC build error
+  supposed to solve error since commit#c5e2b30 bsc#1049297
+- 42.3.99.19
+
+-------------------------------------------------------------------
 Wed Jan 17 13:33:36 CET 2018 - snwint@suse.de
 
 - rewrite partitioning section to use new storage-ng setting

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        42.3.99.18
+Version:        42.3.99.19
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT
@@ -132,7 +132,7 @@ install -m 644 control/${CONTROL_FILE} $RPM_BUILD_ROOT%{?skelcdpath}/CD1/control
     sed -i -e "s,http://download.opensuse.org/source/,http://download.opensuse.org/ports/$ports_arch/source/," %{buildroot}%{?skelcdpath}/CD1/control.xml
     sed -i -e "s,http://download.opensuse.org/update/tumbleweed/,http://download.opensuse.org/ports/$ports_arch/update/tumbleweed/," %{buildroot}%{?skelcdpath}/CD1/control.xml
     #we parse out non existing non-oss repo for ports
-    xsltproc -o %{buildroot}%{?skelcdpath}/CD1/control.xml control/nonoss.xsl %{buildroot}%{?skelcdpath}/CD1/control.xml/
+    xsltproc -o %{buildroot}%{?skelcdpath}/CD1/control_ports.xml control/nonoss.xsl %{buildroot}%{?skelcdpath}/CD1/control.xml
     mv %{buildroot}%{?skelcdpath}/CD1/control{_ports,}.xml
     xmllint --noout --relaxng %{_datadir}/YaST2/control/control.rng %{buildroot}%{?skelcdpath}/CD1/control.xml
 %endif


### PR DESCRIPTION
supposed to solve error since
commit#c5e2b30ae60196059134db87e0c462b67d32618f

build error as per 
https://build.opensuse.org/package/live_build_log/openSUSE:Factory:PowerPC:Rings:1-MinimalX/skelcd-control-openSUSE/standard/ppc64le
```
[   59s] + xsltproc -o /home/abuild/rpmbuild/BUILDROOT/skelcd-control-openSUSE-42.3.99.18-3.1.ppc64le/CD1/control.xml control/nonoss.xsl /home/abuild/rpmbuild/BUILDROOT/skelcd-control-openSUSE-42.3.99.18-3.1.ppc64le/CD1/control.xml/
[   59s] warning: failed to load external entity "/home/abuild/rpmbuild/BUILDROOT/skelcd-control-openSUSE-42.3.99.18-3.1.ppc64le/CD1/control.xml/"
[   59s] unable to parse /home/abuild/rpmbuild/BUILDROOT/skelcd-control-openSUSE-42.3.99.18-3.1.ppc64le/CD1/control.xml/
[   59s] error: Bad exit status from /var/tmp/rpm-tmp.NnrXyD (%install)
```