### PR TITLE
 Add 'fcoe-client' to the list of clonable modules

### DIFF
--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -347,6 +347,7 @@ textdomain="control"
         <clone_module>printer</clone_module>
         <clone_module>add-on</clone_module>
         <clone_module>iscsi-client</clone_module>
+        <clone_module>fcoe-client</clone_module>
         <clone_module>software</clone_module>
         <clone_module>partitioning</clone_module>
         <clone_module>bootloader</clone_module>

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Mar  8 17:05:54 UTC 2018 - knut.anderssen@suse.com
+
+- Added the fcoe-client to the list of clonable modules
+  (bsc#1078991).
+- 42.2.7
+
+-------------------------------------------------------------------
 Tue Oct 11 15:06:37 UTC 2016 - lnussel@suse.de
 
 - add back Enlightenment to desktop selection

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        42.2.6
+Version:        42.2.7
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT


### PR DESCRIPTION
- https://trello.com/c/eLMiRWmH/1350-2-bug-1078991-l3-autoyast-unable-to-find-disk-with-option-withfcoe