### PR TITLE
Add 'fcoe-client' to the list of clonable modules

### DIFF
--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -501,6 +501,7 @@ textdomain="control"
         <clone_module>printer</clone_module>
         <clone_module>add-on</clone_module>
         <clone_module>iscsi-client</clone_module>
+        <clone_module>fcoe-client</clone_module>
         <clone_module>software</clone_module>
         <clone_module>partitioning</clone_module>
         <clone_module>bootloader</clone_module>

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Mar  8 17:05:54 UTC 2018 - knut.anderssen@suse.com
+
+- Added the fcoe-client to the list of clonable modules
+  (bsc#1078991).
+- 15.0.5
+
+-------------------------------------------------------------------
 Mon Mar  5 14:54:11 UTC 2018 - rbrown@suse.com
 
 - remove boo#1078495 workaround, causes more problems than solved

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        15.0.4
+Version:        15.0.5
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT


### PR DESCRIPTION
- [Trello Card](https://trello.com/c/eLMiRWmH/1350-2-bug-1078991-l3-autoyast-unable-to-find-disk-with-option-withfcoe)