### PR TITLE
Add 'fcoe-client' to the list of clonable modules (TW)

### DIFF
--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -460,6 +460,7 @@ textdomain="control"
         <clone_module>printer</clone_module>
         <clone_module>add-on</clone_module>
         <clone_module>iscsi-client</clone_module>
+        <clone_module>fcoe-client</clone_module>
         <clone_module>software</clone_module>
         <clone_module>partitioning</clone_module>
         <clone_module>bootloader</clone_module>

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Mar  8 17:05:54 UTC 2018 - knut.anderssen@suse.com
+
+- Added the fcoe-client to the list of clonable modules
+  (bsc#1078991).
+- 42.3.99.20
+
+-------------------------------------------------------------------
 Mon Jan 22 16:30:06 UTC 2018 - normand@linux.vnet.ibm.com
 
 - in spec file change xsltproc parms to avoid PowerPC build error

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        42.3.99.19
+Version:        42.3.99.20
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT


### PR DESCRIPTION
- Originally the idea was to merge openSUSE-15_0 branch, but taking in account the number of changes will add the commits separately.

- [Trello Card](https://trello.com/c/eLMiRWmH/1350-2-bug-1078991-l3-autoyast-unable-to-find-disk-with-option-withfcoe)