### PR TITLE
Adjust update repo for ports

### DIFF
--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jun 12 10:18:07 UTC 2018 - dmueller@suse.com
+
+- Fix update repository for ports
+- 15.0.14
+
+-------------------------------------------------------------------
 Mon May 14 07:59:05 UTC 2018 - igonzalezsosa@suse.com
 
 - Add yast2-configuration-management to the installation media

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        15.0.13
+Version:        15.0.14
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT
@@ -131,6 +131,7 @@ install -m 644 control/${CONTROL_FILE} $RPM_BUILD_ROOT%{?skelcdpath}/CD1/control
     sed -i -e "s,http://download.opensuse.org/tumbleweed/,http://download.opensuse.org/ports/$ports_arch/tumbleweed/," %{buildroot}%{?skelcdpath}/CD1/control.xml
     sed -i -e "s,http://download.opensuse.org/debug/,http://download.opensuse.org/ports/$ports_arch/debug/," %{buildroot}%{?skelcdpath}/CD1/control.xml
     sed -i -e "s,http://download.opensuse.org/source/,http://download.opensuse.org/ports/$ports_arch/source/," %{buildroot}%{?skelcdpath}/CD1/control.xml
+    sed -i -e "s,http://download.opensuse.org/update/leap/,http://download.opensuse.org/ports/update/leap/," %{buildroot}%{?skelcdpath}/CD1/control.xml
     sed -i -e "s,http://download.opensuse.org/update/tumbleweed/,http://download.opensuse.org/ports/$ports_arch/update/tumbleweed/," %{buildroot}%{?skelcdpath}/CD1/control.xml
     #we parse out non existing non-oss repo for ports
     xsltproc -o %{buildroot}%{?skelcdpath}/CD1/control_ports.xml control/nonoss.xsl %{buildroot}%{?skelcdpath}/CD1/control.xml


### PR DESCRIPTION
Unlike all the other repositories, the ports updates are not
under /ports/$portsarch/ but under /ports/update (e.g. all
architectures under one directory). Special case this exception
for leap (it is "normal" for tumbleweed). The reason for
this is in how the opensuse maintenance engine works (it
can handle only one Update project for each arches) so it
cannot be changed easily.