### PR TITLE
Adjust update repo for ports

### DIFF
--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,3 +1,10 @@
+------------------------------------------------------------------
+Mon Mar 25 11:13:31 UTC 2019 - Dirk Mueller <dmueller@suse.com>
+
+- Fix update repository for ports (forward port of change that
+  went into Leap 15.0) (bsc#1101334)
+- 20190325
+
 -------------------------------------------------------------------
 Mon Mar 25 10:26:35 UTC 2019 - Guillaume GARDET <guillaume@opensuse.org>
 

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        20190312
+Version:        20190325
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT
@@ -136,6 +136,7 @@ install -m 644 control/${CONTROL_FILE} $RPM_BUILD_ROOT%{?skelcdpath}/CD1/control
     sed -i -e "s,http://download.opensuse.org/tumbleweed/,http://download.opensuse.org/ports/$ports_arch/tumbleweed/," %{buildroot}%{?skelcdpath}/CD1/control.xml
     sed -i -e "s,http://download.opensuse.org/debug/,http://download.opensuse.org/ports/$ports_arch/debug/," %{buildroot}%{?skelcdpath}/CD1/control.xml
     sed -i -e "s,http://download.opensuse.org/source/,http://download.opensuse.org/ports/$ports_arch/source/," %{buildroot}%{?skelcdpath}/CD1/control.xml
+    sed -i -e "s,http://download.opensuse.org/update/leap/,http://download.opensuse.org/ports/update/leap/," %{buildroot}%{?skelcdpath}/CD1/control.xml
     sed -i -e "s,http://download.opensuse.org/update/tumbleweed/,http://download.opensuse.org/ports/$ports_arch/update/tumbleweed/," %{buildroot}%{?skelcdpath}/CD1/control.xml
     #we parse out non existing non-oss repo for ports
     xsltproc -o %{buildroot}%{?skelcdpath}/CD1/control_ports.xml control/nonoss.xsl %{buildroot}%{?skelcdpath}/CD1/control.xml


### PR DESCRIPTION
Unlike all the other repositories, the ports updates are not
under /ports/$portsarch/ but under /ports/update (e.g. all
architectures under one directory). Special case this exception
for leap (it is "normal" for tumbleweed). The reason for
this is in how the opensuse maintenance engine works (it
can handle only one Update project for each arches) so it
cannot be changed easily.

Forward port to master to ensure this doesn't get lost
again when openSUSE Leap 15.1 or 16 gets branched.