### PR TITLE
Remove 'Custom' system_role (boo#1100417)

### DIFF
--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -516,16 +516,6 @@ textdomain="control"
             </volumes>
           </partitioning>
       </system_role>
-
-      <system_role>
-        <id>custom</id>
-        <software>
-          <!-- The "custom" role displays manual the pattern selection
-               dialog in the installation workflow. (bnc#1031295) -->
-          <default_patterns>base enhanced_base</default_patterns>
-        </software>
-        <order config:type="integer">500</order>
-      </system_role>
     </system_roles>
 
     <clone_modules config:type="list">
@@ -622,13 +612,6 @@ configured accordingly to match the use case of the role. &lt;/p&gt;</label>
 • Update using `transactional-update up`, then reboot for the update to take effect
           </label>
         </serverro_description>
-        <custom>
-          <!-- TRANSLATORS: a label for a system role -->
-          <label>Custom</label>
-        </custom>
-        <custom_description>
-          <label>The custom selection allows to select alternative software patterns to customize the installation. Additional software is available in the online repositories.</label>
-        </custom_description>
     </texts>
 
     <proposals config:type="list">
@@ -942,11 +925,6 @@ configured accordingly to match the use case of the role. &lt;/p&gt;</label>
                 <module>
                     <label>Add-On Products</label>
                     <name>add-on</name>
-                </module>
-                <module>
-                    <label>Custom Pattern Selection</label>
-                    <name>custom_patterns</name>
-                    <enable_back>yes</enable_back>
                 </module>
                 <module>
                     <label>Disk</label>

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jul 19 16:31:10 UTC 2018 - rbrown@suse.com
+
+- Remove 'Custom' system_role due to incompatibily with SLE-15 role
+  screen (bsc#1100417)
+- 15.1.2
+
+-------------------------------------------------------------------
 Tue Jul 17 08:18:24 UTC 2018 - mlin@suse.com
 
 - Update all 15.0 related part to 15.1

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        15.1.1
+Version:        15.1.2
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT


### PR DESCRIPTION
Removed after discussion in the openSUSE Release Engineering team - any common functionality hindered by the removal of this system role can be returned with the addition of new system roles in the future