### PR TITLE
Upgrade from openSUSE Leap 15.x is supported (bsc#1105335)

### DIFF
--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -84,6 +84,8 @@ textdomain="control"
             <regexp_item>^openSUSE 13\..*$</regexp_item>
             <!-- Updating from openSUSE Leap 42.x -->
             <regexp_item>^openSUSE Leap 42\..*$</regexp_item>
+            <!-- Updating from openSUSE Leap 15.x -->
+            <regexp_item>^openSUSE Leap 15\..*$</regexp_item>
             <!-- old TW snapshots -->
             <regexp_item>^openSUSE 20[0-9]*$</regexp_item>
             <!-- new TW snapshots -->

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Aug 30 06:56:10 UTC 2018 - lslezak@suse.cz
+
+- Mark the upgrade from openSUSE Leap 15.x as supported
+  (bsc#1105335)
+- 42.3.99.31
+
+-------------------------------------------------------------------
 Thu Jul 19 16:31:10 UTC 2018 - rbrown@suse.com
 
 - Remove 'Custom' system_role due to incompatibily with SLE-15 role

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        42.3.99.30
+Version:        42.3.99.31
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1105335
- The list of regexps contained only "openSUSE Leap 42.x" product, the version 15.0 was not marked as supported.
- 42.3.99.31