### PR TITLE
Updated "rake version:bump" task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -16,3 +16,30 @@ end
 # generate the *-promo files when creating the tarball
 task :tarball => :create_promo
 
+# this package uses the date versioning in master (for openSUSE Tumbleweed),
+# replace the standard yast task implementation
+Rake::Task[:'version:bump'].clear
+namespace :version do
+  desc "Update version in the package/skelcd-control-openSUSE.spec file"
+  task :bump do
+    spec_file = "package/skelcd-control-openSUSE.spec"
+    spec = File.read(spec_file)
+
+    # parse the current version, it can be in <date> or <date>.<release> format
+    _, version, release = spec.match(/^\s*Version:\s*(\w+)(?:\.(\w+))?$/).to_a
+    # use the UTC time to avoid conflicts when updating from different time zones
+    date = Time.now.utc.strftime("%Y%m%d")
+
+    # add a release version if the package has been already updated today
+    new_version = if version == date
+      # if the release was missing it starts from 1
+      "#{date}.#{release.to_i + 1}"
+    else
+      "#{date}"
+    end
+
+    puts "Updating to #{new_version}"
+    spec.gsub!(/^\s*Version:.*$/, "Version:        #{new_version}")
+    File.write(spec_file, spec)
+  end
+end


### PR DESCRIPTION
## Summary

- Updated the `rake version:bump` task to work properly with the new versioning schema in master,
  see #148 for the details.

## Notes

- It uses just the current date if the old version is different, e.g. `20181110` => `20181113`
- If the package has been already released today it adds a release version starting with 1:  
  `20181113` => `20181113.1`
- The next updates will increase the release version: `20181113.2`,  `20181113.3`, `20181113.4`, ...
- The next day (or anytime later) the version is updated and the release is removed:
   `20181113.3` => `20181114`
- It uses the UTC date to avoid possible conflicts when running on the same day but in different time zones by different developers.