### PR TITLE
Added workflow step to add online repos during installation

### DIFF
--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -890,6 +890,12 @@ configured accordingly to match the use case of the role. &lt;/p&gt;</label>
                     <label>System Analysis</label>
                     <name>system_analysis</name>
                 </module>
+                <!-- bsc#1112937: Online repos during installation -->
+                <module>
+                    <label>Online Repositories</label>
+                    <name>productsources</name>
+                    <enable_back>yes</enable_back>
+                </module>
                 <module>
                     <name>download_release_notes</name>
                 </module>

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Nov 14 13:55:08 UTC 2018 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Added workflow step to add online repos during installation
+  (bsc#1112937)
+- 20181114
+
+-------------------------------------------------------------------
 Sat Nov 10 21:05:05 UTC 2018 - hellcp@opensuse.org
 
 - Switch installation UI for openSUSE to sidebar (boo#1088785) 

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        20181113
+Version:        20181114
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT


### PR DESCRIPTION
## Trello

https://trello.com/c/VgNO1EBi/442-ludwigs-favorite-feature-leap-151-add-possibility-to-add-online-updates-repo-during-installation

## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1112937

## Changes

This adds the "online repos" step to the installation workflow.

This step was always there for the upgrade workflow; now it is also there for the installation.

The module itself takes care to skip itself to first ask if the user wishes to activate online repos. It also auto-skips itself if no network is configured; network configuration is done earlier in the workflow.

## Related PR

https://github.com/yast/yast-packager/pull/385

## Stakeholder Feedback

Demonstrated to and approved by @lnussel .