### PR TITLE
Explicitly check the changelog sequence

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -8,3 +8,8 @@ make -C control check
 # see https://github.com/yast/docker-yast-ruby/blob/master/yast-travis-ruby
 yast-travis-ruby
 
+# explicitly check the changelog sequence, the source_validator is fine if at least one
+# *.changes file is OK, but here we need to be sure that both are correct
+/usr/lib/obs/service/source_validators/helpers/convert_changes_to_rpm_changelog --check < package/skelcd-control-openSUSE.changes
+/usr/lib/obs/service/source_validators/helpers/convert_changes_to_rpm_changelog --check < package/skelcd-control-openSUSE-promo.changes
+


### PR DESCRIPTION
- This fixes Travis not failing when an error is found in the changes, see [this Travis build](https://travis-ci.org/yast/skelcd-control-openSUSE/builds/458436408#L393).
- The `source_validator` is fine when at least one changes file is correct, we need to be sure both are OK.
