### PR TITLE
Add Xfce system role

### DIFF
--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -573,10 +573,10 @@ configured accordingly to match the use case of the role. &lt;/p&gt;</label>
         </gnome_description>
         <xfce>
           <!-- TRANSLATORS: a label for a system role -->
-          <label>Desktop with XFCE</label>
+          <label>Desktop with Xfce</label>
         </xfce>
         <xfce_description>
-          <label>Graphical system with XFCE as desktop environment. Suitable for Workstations, Desktops and Laptops.</label>
+          <label>Graphical system with Xfce as desktop environment. Suitable for Workstations, Desktops and Laptops.</label>
         </xfce_description>   
 	<generic_desktop>
           <!-- TRANSLATORS: a label for a system role -->

--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -576,7 +576,14 @@ configured accordingly to match the use case of the role. &lt;/p&gt;</label>
 	  <label>Graphical system with GNOME as desktop environment. Suitable for Workstations, Desktops and Laptops.
 	  </label>
         </gnome_description>
-        <generic_desktop>
+        <xfce>
+          <!-- TRANSLATORS: a label for a system role -->
+          <label>Desktop with XFCE</label>
+        </xfce>
+        <xfce_description>
+          <label>Graphical system with XFCE as desktop environment. Suitable for Workstations, Desktops and Laptops.</label>
+        </xfce_description>   
+	<generic_desktop>
           <!-- TRANSLATORS: a label for a system role -->
           <label>Generic Desktop</label>
         </generic_desktop>

--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -337,6 +337,17 @@ textdomain="control"
         </software>
         <order config:type="integer">200</order>
       </system_role>
+	    
+      <system_role>
+        <id>xfce</id>
+        <network>
+          <network_manager>always</network_manager>
+        </network>
+        <software>
+          <default_patterns>xfce x11 base</default_patterns>
+        </software>
+        <order config:type="integer">220</order>
+      </system_role>
 
       <system_role>
         <id>generic_desktop</id>

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,10 @@
 ------------------------------------------------------------------
+Fri Apr  5 09:29:00 UTC 2019 - Maurizio Galli <maurizio.galli@gmail.com>
+
+- Added Xfce System Role to Yast Installer  (boo#1131666)
+- 20190405
+
+-------------------------------------------------------------------
 Mon Mar 25 11:13:31 UTC 2019 - Dirk Mueller <dmueller@suse.com>
 
 - Fix update repository for ports (forward port of change that
@@ -43,12 +49,7 @@ Wed Feb 13 08:41:14 UTC 2019 - jsegitz@suse.com
 - 20190213
 
 -------------------------------------------------------------------
-Fri Apr  5 09:29:00 UTC 2019 - Maurizio Galli <maurizio.galli@gmail.com>
 
-- Added Xfce System Role to Yast Installer  (boo#1131666)
-- 20190405
-
--------------------------------------------------------------------
 Fri Dec 07 14:16:26 UTC 2018 - Richard Brown <rbrown@suse.com>
 
 - Adjust / partition size to fit with 20GB aspirational minimum

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Apr  5 09:29:00 UTC 2019 - Maurizio Galli <maurizio.galli@gmail.com>
+
+- Added Xfce System Role to Yast Installer  (boo#1131666)
+- 20190405
+
+-------------------------------------------------------------------
 Fri Dec 07 14:16:26 UTC 2018 - Richard Brown <rbrown@suse.com>
 
 - Adjust / partition size to fit with 20GB aspirational minimum

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        20181207
+Version:        20190405
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT


### PR DESCRIPTION
Having a system role for Xfce in the installer has two main advantages:
1) The Xfce desktop is already included in the DVD media, it would make sense to have it as on option to select from the start. Although not as popular as KDE and GNOME, Xfce has a fair amount of users in the openSUSE community.
2) As I'm  creating Live XFCE media , this step would make the installer in the live cd easier to set up. The current setup forces the user to go through the "generic desktop", an extra step that is not intuitive for the average user.

