### PR TITLE
Add network to installation proposal overview page

### DIFF
--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -630,6 +630,10 @@ configured accordingly to match the use case of the role. &lt;/p&gt;</label>
                     <presentation_order>97</presentation_order>
                 </proposal_module>
                 <proposal_module>
+                    <name>network</name>
+                    <presentation_order>98</presentation_order>
+                </proposal_module>
+                <proposal_module>
                     <name>clone</name>
                     <presentation_order>99</presentation_order>
                 </proposal_module>
@@ -679,6 +683,10 @@ configured accordingly to match the use case of the role. &lt;/p&gt;</label>
                 <proposal_module>
                     <name>firewall</name>
                     <presentation_order>50</presentation_order>
+                </proposal_module>
+                <proposal_module>
+                    <name>network</name>
+                    <presentation_order>55</presentation_order>
                 </proposal_module>
             </proposal_modules>
         </proposal>

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Feb 25 14:52:21 UTC 2019 - dgonzalez@suse.com
+
+- Add network to the installation proposal (fate#326480).
+- 15.1.12
+
+-------------------------------------------------------------------
 Wed Feb 13 08:36:09 UTC 2019 - jsegitz@suse.com
 
 - Enable firewall by default in server install profiles (boo#1090372)

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        15.1.11
+Version:        15.1.12
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT


### PR DESCRIPTION
Displays Network Proposal in Installation Proposal

- https://fate.suse.com/326480
- https://trello.com/c/4ptXAFVW/441-network-proposal-in-leap-151-networkmanager
- https://trello.com/c/eBiqtDo7/706-2-bug-1124478-and-1124498-build-1584-switching-from-nm-to-wicked-and-back-and-forth


![screenshot_test_2019-02-25_16 25 52](https://user-images.githubusercontent.com/1691872/53352148-2d182200-391a-11e9-9e48-67eca8032619.png)

![screenshot_test_2019-02-25_16 26 02](https://user-images.githubusercontent.com/1691872/53352202-428d4c00-391a-11e9-9483-84a69b8da03d.png)


- ***Related PR:* https://github.com/yast/yast-network/pull/727**


