### PR TITLE
Add network to installation proposal overview page

### DIFF
--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -625,6 +625,10 @@ configured accordingly to match the use case of the role. &lt;/p&gt;</label>
                     <presentation_order>97</presentation_order>
                 </proposal_module>
                 <proposal_module>
+                    <name>network</name>
+                    <presentation_order>98</presentation_order>
+                </proposal_module>
+                <proposal_module>
                     <name>clone</name>
                     <presentation_order>99</presentation_order>
                 </proposal_module>
@@ -674,6 +678,10 @@ configured accordingly to match the use case of the role. &lt;/p&gt;</label>
                 <proposal_module>
                     <name>firewall</name>
                     <presentation_order>50</presentation_order>
+                </proposal_module>
+                <proposal_module>
+                    <name>network</name>
+                    <presentation_order>55</presentation_order>
                 </proposal_module>
             </proposal_modules>
         </proposal>

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Feb 25 15:25:59 UTC 2019 - dgonzalez@suse.com
+
+- Add network to the installation proposal (fate#326480).
+- 20190225
+
+-------------------------------------------------------------------
 Wed Feb 13 08:41:14 UTC 2019 - jsegitz@suse.com
 
 - Enable firewall by default in server install profiles (boo#1090372)

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        20190213
+Version:        20190225
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT


### PR DESCRIPTION
Displays Network Proposal in Installation Proposal

- https://fate.suse.com/326480
- https://trello.com/c/4ptXAFVW/441-network-proposal-in-leap-151-networkmanager
- https://trello.com/c/eBiqtDo7/706-2-bug-1124478-and-1124498-build-1584-switching-from-nm-to-wicked-and-back-and-forth
- ***The same as https://github.com/yast/skelcd-control-openSUSE/pull/169, but for TW***

---

- ***Related PR:* https://github.com/yast/yast-network/pull/727**

