### PR TITLE
Remove not necessary step names

### DIFF
--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -863,7 +863,7 @@ configured accordingly to match the use case of the role. &lt;/p&gt;</label>
             <stage>initial</stage>
             <modules config:type="list">
                 <module>
-                    <label>Load linuxrc Network Configuration</label>
+                    <label>Network Autosetup</label>
                     <name>install_inf</name>
                 </module>
                 <module>
@@ -969,7 +969,7 @@ TODO: prepare disk here when it does not break space calculation (and remove bel
                 the file system or storage kernel modules from inst-sys. They need to be already
                 loaded and active. -->
                 <module>
-                    <label>Installer Cleanup</label>
+                    <label>Perform Installation</label>
                     <name>instsys_cleanup</name>
                 </module>
                 <!-- Installation from images -->
@@ -1022,7 +1022,7 @@ TODO: prepare disk here when it does not break space calculation (and remove bel
             <stage>initial</stage>
             <modules config:type="list">
                 <module>
-                    <label>Load linuxrc Network Configuration</label>
+                    <label>Network Autosetup</label>
                     <name>install_inf</name>
                 </module>
                 <module>
@@ -1103,7 +1103,7 @@ TODO: prepare disk here when it does not break space calculation (and remove bel
                 the file system or storage kernel modules from inst-sys. They need to be already
                 loaded and active. -->
                 <module>
-                    <label>Installer Cleanup</label>
+                    <label>Perform Update</label>
                     <name>instsys_cleanup</name>
                 </module>
                 <module>
@@ -1187,11 +1187,11 @@ TODO: prepare disk here when it does not break space calculation (and remove bel
                 the file system or storage kernel modules from inst-sys. They need to be already
                 loaded and active. -->
                 <module>
-                    <label>Installer Cleanup</label>
+                    <label>Perform Installation</label>
                     <name>instsys_cleanup</name>
                 </module>
                 <module>
-                <label>Perform Installation</label>
+                    <label>Perform Installation</label>
                     <name>deploy_image</name>
                 </module>
                 <module>
@@ -1294,7 +1294,7 @@ TODO: prepare disk here when it does not break space calculation (and remove bel
                 the file system or storage kernel modules from inst-sys. They need to be already
                 loaded and active. -->
                 <module>
-                    <label>Installer Cleanup</label>
+                    <label>Perform Update</label>
                     <name>instsys_cleanup</name>
                 </module>
                 <module>

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Feb 26 12:00:01 UTC 2019 - dgonzalez@suse.com
+
+- Remove not needed step names from the sidebar
+  (bsc#1115986, bsc#1126509).
+- 15.1.13
+
+-------------------------------------------------------------------
 Mon Feb 25 14:52:21 UTC 2019 - dgonzalez@suse.com
 
 - Add network to the installation proposal (fate#326480).

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        15.1.12
+Version:        15.1.13
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT


### PR DESCRIPTION
The same as https://github.com/yast/skelcd-control-openSUSE/pull/154, but for Leap.

It simply changes "Load Linuxrc Network Configuration" by "Network Autosetup" and remove some repeated steps. (see the screenshots for TW in the referenced commit).

Related to https://bugzilla.suse.com/show_bug.cgi?id=1115986 and more recently to https://bugzilla.suse.com/show_bug.cgi?id=1126509