### PR TITLE
Default to wicked on generic desktop role

### DIFF
--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -340,9 +340,6 @@ textdomain="control"
 
       <system_role>
         <id>generic_desktop</id>
-        <network>
-          <network_manager>always</network_manager>
-        </network>
         <software>
           <default_patterns>x11 base</default_patterns>
         </software>

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Mar 12 11:55:40 UTC 2019 - Dominique Leuenberger <dimstar@opensuse.org>
+
+- Default to wicked on generic desktop: do the same as we did
+  before yast learned to auto-pick NetworkManager if the
+  control.xml happened to request it (bsc#1127228).
+- 20190326
+
+-------------------------------------------------------------------
 Tue Mar 12 11:42:39 UTC 2019 - Dominique Leuenberger <dimstar@opensuse.org>
 
 - Changed product_license_dir define from /etc/YaST2/licenses/base/

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        20190312
+Version:        20190326
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT


### PR DESCRIPTION
In the past, yast silently ignored this setting and went for wicked
if NetworkManager did not get installed. Since yast2-network 4.1.40,
this is no longer the case: if the role asked for NetworkManager,
yast now selects NM for installation to comply to he request.

The generic desktop role is a minimal X environment, where no
NetworkManager applet is pre-installed by default. So staying with
wicked, as it used to be by accident, is what we want not by definition.