### PR TITLE
Update path for base product license

### DIFF
--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -59,7 +59,7 @@ textdomain="control"
         <kexec_reboot config:type="boolean">true</kexec_reboot>
 
         <!-- FATE: #304865: Enhance YaST Modules to cooperate better handling the product licenses -->
-        <base_product_license_directory>/etc/YaST2/licenses/base/</base_product_license_directory>
+        <base_product_license_directory>/usr/share/licenses/product/base/</base_product_license_directory>
 
         <!-- #303798: YaST2 runlevel editor: offer easy enablement and configuration of runlevel 4 -->
         <rle_offer_rulevel_4 config:type="boolean">false</rle_offer_rulevel_4>

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Mar 13 14:29:14 UTC 2019 - David Díaz <dgonzalez@suse.com>
+
+- Change path for base product license to
+  /usr/share/licenses/product/base (fate#324053, jsc#SLE-3067,
+  jsc#SLE-4173).
+- 15.1.14
+
+-------------------------------------------------------------------
 Tue Feb 26 12:00:01 UTC 2019 - dgonzalez@suse.com
 
 - Remove not needed step names from the sidebar

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        15.1.13
+Version:        15.1.14
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT


### PR DESCRIPTION
After changes made for fate#324053 / jsc#SLE-4173, the license for the base product will be located at `/usr/share/licenses/product/base` instead of `/etc/YaST2/licenses/base`.

Related to #173 and #175.

Also discussed in https://github.com/yast/skelcd-control-Kubic/pull/31

---

More info available in fate#324053, jsc#SLE-3067, and jsc#SLE-4173