### PR TITLE
Adjust update repo for ports

### DIFF
--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -5,6 +5,11 @@ Mon Mar 25 11:17:45 UTC 2019 - Dirk Mueller <dmueller@suse.com>
 - 15.1.15
 
 -------------------------------------------------------------------
+Mon Mar 25 10:26:35 UTC 2019 - Guillaume GARDET <guillaume@opensuse.org>
+
+- Fix %arm links
+
+-------------------------------------------------------------------
 Wed Mar 13 14:29:14 UTC 2019 - David Díaz <dgonzalez@suse.com>
 
 - Change path for base product license to

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Mar 25 11:17:45 UTC 2019 - Dirk Mueller <dmueller@suse.com>
+
+- Fix update repository for ports (bsc#1101334)
+- 15.1.15
+
+-------------------------------------------------------------------
 Wed Mar 13 14:29:14 UTC 2019 - David Díaz <dgonzalez@suse.com>
 
 - Change path for base product license to

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        15.1.14
+Version:        15.1.15
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT
@@ -131,6 +131,7 @@ install -m 644 control/${CONTROL_FILE} $RPM_BUILD_ROOT%{?skelcdpath}/CD1/control
     sed -i -e "s,http://download.opensuse.org/tumbleweed/,http://download.opensuse.org/ports/$ports_arch/tumbleweed/," %{buildroot}%{?skelcdpath}/CD1/control.xml
     sed -i -e "s,http://download.opensuse.org/debug/,http://download.opensuse.org/ports/$ports_arch/debug/," %{buildroot}%{?skelcdpath}/CD1/control.xml
     sed -i -e "s,http://download.opensuse.org/source/,http://download.opensuse.org/ports/$ports_arch/source/," %{buildroot}%{?skelcdpath}/CD1/control.xml
+    sed -i -e "s,http://download.opensuse.org/update/leap/,http://download.opensuse.org/ports/update/leap/," %{buildroot}%{?skelcdpath}/CD1/control.xml
     sed -i -e "s,http://download.opensuse.org/update/tumbleweed/,http://download.opensuse.org/ports/$ports_arch/update/tumbleweed/," %{buildroot}%{?skelcdpath}/CD1/control.xml
     #we parse out non existing non-oss repo for ports
     xsltproc -o %{buildroot}%{?skelcdpath}/CD1/control_ports.xml control/nonoss.xsl %{buildroot}%{?skelcdpath}/CD1/control.xml

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -122,10 +122,15 @@ mkdir -p $RPM_BUILD_ROOT%{?skelcdpath}/CD1
 install -m 644 control/${CONTROL_FILE} $RPM_BUILD_ROOT%{?skelcdpath}/CD1/control.xml
 
 %ifarch aarch64 %arm ppc ppc64 ppc64le
+    ports_arch="%{_arch}"
     %ifarch ppc ppc64 ppc64le
         ports_arch="ppc"
-    %else
-        ports_arch="%{_arch}"
+    %endif
+    %ifarch armv6l armv6hl
+        ports_arch="armv6hl"
+    %endif
+    %ifarch armv7l armv7hl
+        ports_arch="armv7hl"
     %endif
     sed -i -e "s,http://download.opensuse.org/distribution/,http://download.opensuse.org/ports/$ports_arch/distribution/," %{buildroot}%{?skelcdpath}/CD1/control.xml
     sed -i -e "s,http://download.opensuse.org/tumbleweed/,http://download.opensuse.org/ports/$ports_arch/tumbleweed/," %{buildroot}%{?skelcdpath}/CD1/control.xml


### PR DESCRIPTION
Unlike all the other repositories, the ports updates are not
under /ports/$portsarch/ but under /ports/update (e.g. all
architectures under one directory). Special case this exception
for leap (it is "normal" for tumbleweed). The reason for
this is in how the opensuse maintenance engine works (it
can handle only one Update project for each arches) so it
cannot be changed easily.