### PR TITLE
Added a pull request reminder

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,6 @@
+Note for the pull request authors:
+
+The `master` branch is intended for the openSUSE Tumbleweed only,
+if you want to have the same change in the openSUSE Leap then backport
+it to the respective `openSUSE-X_Y` branch.
+


### PR DESCRIPTION
The issue #179 was very likely caused just by fixing the #151 problem only in the `master` branch.

But at that time the Leap 15.1 was already branched (in contrast to the other YaST packages) so it was easy to overlook the fact that the change should have been also backported to the `openSUSE-15_1` branch.

Having a reminder in the pull request template should hopefully avoid this issue.