### PR TITLE
Make sure YaST is installed with Xfce system role too in Tumbleweed

### DIFF
--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -337,14 +337,14 @@ textdomain="control"
         </software>
         <order config:type="integer">200</order>
       </system_role>
-	    
+
       <system_role>
         <id>xfce</id>
         <network>
           <network_manager>always</network_manager>
         </network>
         <software>
-          <default_patterns>xfce x11 base</default_patterns>
+          <default_patterns>xfce x11 base x11_yast yast2_basis</default_patterns>
         </software>
         <order config:type="integer">220</order>
       </system_role>
@@ -576,8 +576,9 @@ configured accordingly to match the use case of the role. &lt;/p&gt;</label>
           <label>Desktop with Xfce</label>
         </xfce>
         <xfce_description>
-          <label>Graphical system with Xfce as desktop environment. Suitable for Workstations, Desktops and Laptops.</label>
-        </xfce_description>   
+          <label>Graphical system with Xfce as desktop environment. Suitable for Workstations, Desktops and Laptops.
+          </label>
+        </xfce_description>
 	<generic_desktop>
           <!-- TRANSLATORS: a label for a system role -->
           <label>Generic Desktop</label>

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Apr 30 10:01:57 UTC 2019 - Maurizio Galli <maurizio.galli@gmail.com>
+
+- make sure yast gets installed with Xfce system role too 
+  (boo#1130998)
+- cleaned white spaces around Xfce system role
+- 20190430 
+
+-------------------------------------------------------------------
 Tue Apr 16 07:55:54 UTC 2019 - lnussel@suse.de
 
 - make sure yast gets installed with all roles except

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        20190416
+Version:        20190430
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT


### PR DESCRIPTION
Follow up to PR #182 :
- added `x11_yast` and `yast2_basis` to Xfce system role 
- cleaned white spaces
