### PR TITLE
Generic desktop requires basic_desktop pattern + other fix

### DIFF
--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -352,7 +352,7 @@ textdomain="control"
       <system_role>
         <id>generic_desktop</id>
         <software>
-          <default_patterns>x11 base x11_yast yast2_basis</default_patterns>
+          <default_patterns>basic_desktop x11 base x11_yast yast2_basis</default_patterns>
         </software>
         <order config:type="integer">250</order>
       </system_role>

--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -321,7 +321,7 @@ textdomain="control"
           <network_manager>always</network_manager>
         </network>
         <software>
-          <default_patterns>kde x11 base x11_yast yast2_basis</default_patterns>
+          <default_patterns>kde x11 base enhanced_base x11_yast yast2_basis</default_patterns>
         </software>
         <order config:type="integer">100</order>
         <no_default config:type="boolean">true</no_default>
@@ -333,7 +333,7 @@ textdomain="control"
           <network_manager>always</network_manager>
         </network>
         <software>
-          <default_patterns>gnome x11 base x11_yast yast2_basis</default_patterns>
+          <default_patterns>gnome x11 base enhanced_base x11_yast yast2_basis</default_patterns>
         </software>
         <order config:type="integer">200</order>
       </system_role>
@@ -344,7 +344,7 @@ textdomain="control"
           <network_manager>always</network_manager>
         </network>
         <software>
-          <default_patterns>xfce x11 base x11_yast yast2_basis</default_patterns>
+          <default_patterns>xfce x11 base enhanced_base x11_yast yast2_basis</default_patterns>
         </software>
         <order config:type="integer">220</order>
       </system_role>

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,15 +1,11 @@
 -------------------------------------------------------------------
-Wed Jun 12 08:16:39 UTC 2019 - Simon Lees <sflees@suse.de>
+Fri Jun 28 08:16:39 UTC 2019 - Simon Lees <sflees@suse.de>
 
 - Generic Desktop should also now install basic_desktop patterns
   as it now pulls in icewm rather then X11 (boo#1124865)
-
--------------------------------------------------------------------
-Wed Jun 12 07:16:39 UTC 2019 - Guillaume GARDET <guillaume.gardet@opensuse.org>
-
-- Update link to https://download.opensuse.org/YaST/Repos/*
-  for non-x86 (boo#1120938 and boo#1132748)
-- 20190612
+- Gnome, KDE and XFCE system roles now pull in enhanced_base as
+  they have always done so in the past.
+- 20190628
 
 -------------------------------------------------------------------
 Wed Jun 12 07:16:39 UTC 2019 - Guillaume GARDET <guillaume.gardet@opensuse.org>

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,17 +1,30 @@
 -------------------------------------------------------------------
+Wed Jun 12 08:16:39 UTC 2019 - Simon Lees <sflees@suse.de>
+
+- Generic Desktop should also now install basic_desktop patterns
+  as it now pulls in icewm rather then X11 (boo#1124865)
+
+-------------------------------------------------------------------
 Wed Jun 12 07:16:39 UTC 2019 - Guillaume GARDET <guillaume.gardet@opensuse.org>
 
-- Update link to https://download.opensuse.org/YaST/Repos/* 
+- Update link to https://download.opensuse.org/YaST/Repos/*
+  for non-x86 (boo#1120938 and boo#1132748)
+- 20190612
+
+-------------------------------------------------------------------
+Wed Jun 12 07:16:39 UTC 2019 - Guillaume GARDET <guillaume.gardet@opensuse.org>
+
+- Update link to https://download.opensuse.org/YaST/Repos/*
   for non-x86 (boo#1120938 and boo#1132748)
 - 20190612
 
 -------------------------------------------------------------------
 Tue Apr 30 10:01:57 UTC 2019 - Maurizio Galli <maurizio.galli@gmail.com>
 
-- make sure yast gets installed with Xfce system role too 
+- make sure yast gets installed with Xfce system role too
   (boo#1130998)
 - cleaned white spaces around Xfce system role
-- 20190430 
+- 20190430
 
 -------------------------------------------------------------------
 Tue Apr 16 07:55:54 UTC 2019 - lnussel@suse.de
@@ -127,7 +140,7 @@ Wed Nov 14 13:55:08 UTC 2018 - Stefan Hundhammer <shundhammer@suse.com>
 -------------------------------------------------------------------
 Sat Nov 10 21:05:05 UTC 2018 - hellcp@opensuse.org
 
-- Switch installation UI for openSUSE to sidebar (boo#1088785) 
+- Switch installation UI for openSUSE to sidebar (boo#1088785)
 - 20181113
 
 -------------------------------------------------------------------
@@ -241,7 +254,7 @@ Wed Jan 17 13:33:36 CET 2018 - snwint@suse.de
 -------------------------------------------------------------------
 Tue Dec 12 17:11:12 UTC 2017 - rbrown@suse.com
 
-- adjust subvolume list to have NoCOW /var instead of many 
+- adjust subvolume list to have NoCOW /var instead of many
   subvolumes (boo#1075369)
 - 42.3.99.17
 
@@ -1823,4 +1836,3 @@ Wed Mar 31 19:18:54 CEST 2004 - nashif@suse.de
 Thu Mar 25 03:37:53 CET 2004 - nashif@suse.de
 
 - Initial release
-

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        20190612
+Version:        20190628
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT


### PR DESCRIPTION
Replacement for https://github.com/yast/skelcd-control-openSUSE/pull/189 I had to send it through another branch

Generic desktop requires basic_desktop pattern 


gnome, kde and xfce system roles now pull in the enhanced base pattern as well because they used to do that

