### PR TITLE
Mark openSUSE as the preferred base product

### DIFF
--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -186,6 +186,8 @@ textdomain="control"
                 </window_manager>
             </window_managers>
         </upgrade>
+        <!-- boo#1124590 - Ensure correct product is selected -->
+        <select_product>openSUSE</select_product>
 
     </software>
 

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jul 19 12:25:45 UTC 2019 - Dominique Leuenberger <dimstar@opensuse.org>
+
+- Select product on installation [boo#1124590]
+- 20190719
+
+-------------------------------------------------------------------
 Fri Jun 28 08:16:39 UTC 2019 - Simon Lees <sflees@suse.de>
 
 - Generic Desktop should also now install basic_desktop patterns

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        20190628
+Version:        20190719
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT


### PR DESCRIPTION

Yast was modified for Kubic to have a selector for the base product. This is needed, as in TW's FTP tree, we have MicroOS and openSUSE side-by-side.

So far, this was not needed, as openSUSE was the only product with system_installation defined. For Kubic to have MicroOS as selectable base product, it must provide the symbol as well. This means, that the FTP tree now would have two base products, resulting in the Installer asking for which one to install. Ads we don't want that on the TW NETISO and DVD, we are now preselecting the right product