### PR TITLE
Adapt for the openSUSE Leap 15.2 release (bsc#1141654)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,9 +2,9 @@ require "yast/rake"
 
 Yast::Tasks.configuration do |conf|
   conf.obs_api = "https://api.opensuse.org"
-  conf.obs_target = "openSUSE_Leap_15.1"
-  conf.obs_sr_project = "openSUSE:Leap:15.1"
-  conf.obs_project = "YaST:openSUSE:15.1"
+  conf.obs_target = "openSUSE_Leap_15.2"
+  conf.obs_sr_project = "openSUSE:Leap:15.2"
+  conf.obs_project = "YaST:openSUSE:15.2"
   #lets ignore license check for now
   conf.skip_license_check << /.*/
   conf.exclude_files << /README.md/ #do not pack readme

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Aug 22 08:35:38 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Update the package for the openSUSE Leap 15.2 release (bsc#1141654)
+- 15.2.0
+
+-------------------------------------------------------------------
 Tue Apr 16 07:57:26 UTC 2019 - lnussel@suse.de
 
 - make sure yast gets installed with all roles except

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        15.1.18
+Version:        15.2.0
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT


### PR DESCRIPTION
- Adapt the `Rakefile` to submit to Leap 15.2
- Bump the version to 15.0.x
