### PR TITLE
Fix repo URL for s390x

### DIFF
--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu Mar 26 21:00:00 UTC 2020 - Sergio Lindo <sergiolindo.empresa@gmail.com>
+
+- Fix %s390x links (boo#1165922)
+
+-------------------------------------------------------------------
 Fri Mar 20 08:23:19 UTC 2020 - Guillaume GARDET <guillaume.gardet@opensuse.org>
 
 - Update external link for non-x86 on Leap (bsc#1120938)

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package skelcd-control-openSUSE
 #
-# Copyright (c) 2017 SUSE LINUX GmbH, Nuernberg, Germany.
+# Copyright (c) 2017-2020 SUSE LINUX GmbH, Nuernberg, Germany.
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        20200320
+Version:        20200326
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT
@@ -121,7 +121,7 @@ make %{?_smp_mflags} -C control check
 mkdir -p $RPM_BUILD_ROOT%{?skelcdpath}/CD1
 install -m 644 control/${CONTROL_FILE} $RPM_BUILD_ROOT%{?skelcdpath}/CD1/control.xml
 
-%ifarch aarch64 %arm ppc ppc64 ppc64le
+%ifarch aarch64 %arm ppc ppc64 ppc64le s390x
     ports_arch="%{_arch}"
     %ifarch ppc ppc64 ppc64le
         ports_arch="ppc"
@@ -131,6 +131,9 @@ install -m 644 control/${CONTROL_FILE} $RPM_BUILD_ROOT%{?skelcdpath}/CD1/control
     %endif
     %ifarch armv7l armv7hl
         ports_arch="armv7hl"
+    %endif
+    %ifarch s390x
+        ports_arch="zsystems"
     %endif
     sed -i -e "s,http://download.opensuse.org/distribution/,http://download.opensuse.org/ports/$ports_arch/distribution/," %{buildroot}%{?skelcdpath}/CD1/control.xml
     sed -i -e "s,http://download.opensuse.org/tumbleweed/,http://download.opensuse.org/ports/$ports_arch/tumbleweed/," %{buildroot}%{?skelcdpath}/CD1/control.xml


### PR DESCRIPTION
At the moment the repositories added are for x86_64.