### PR TITLE
Add /boot/grub2/arm64-efi subvolume for all roles

### DIFF
--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -274,6 +274,10 @@ textdomain="control"
                         <path>boot/grub2/s390x-emu</path>
                         <archs>s390</archs>
                     </subvolume>
+                    <subvolume>
+                        <path>boot/grub2/arm64-efi</path>
+                        <archs>aarch64</archs>
+                    </subvolume>
                 </subvolumes>
             </volume>
 

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Mar 12 16:16:57 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Add /boot/grub2/arm64-efi subvolume for all roles (bsc#1162320).
+- 15.2.2
+
+-------------------------------------------------------------------
 Thu Aug 22 15:00:07 UTC 2019 - Ludwig Nussel <lnussel@suse.de>
 
 - request 15.2 server list (bsc#1141654)

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        15.2.1
+Version:        15.2.2
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT


### PR DESCRIPTION
#138 added the `/boot/grub2/arm64-efi` subvolumes but only for the `transactional server` role.
This PR adds this subvolume to the default list, so it is applied to all roles.

A PR to the master branch will follow after this one is approved.

See [bsc#1162320](https://bugzilla.suse.com/show_bug.cgi?id=1162320) for further information.