### PR TITLE
 Add /boot/grub2/arm64-efi subvolume for all roles (TW)

### DIFF
--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -270,6 +270,10 @@ textdomain="control"
                         <path>boot/grub2/s390x-emu</path>
                         <archs>s390</archs>
                     </subvolume>
+                    <subvolume>
+                        <path>boot/grub2/arm64-efi</path>
+                        <archs>aarch64</archs>
+                    </subvolume>
                 </subvolumes>
             </volume>
 

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Mar 12 16:16:57 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Add /boot/grub2/arm64-efi subvolume for all roles (bsc#1162320).
+- 20200312
+
+-------------------------------------------------------------------
 Fri Aug 02 13:17:11 UTC 2019 - Richard Brown <rbrown@suse.de>
 
 - Add /boot/writable subvolume to Transactional Server [boo#1138725]

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        20190802
+Version:        20200312
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT


### PR DESCRIPTION
#138 added the `/boot/grub2/arm64-efi` subvolumes but only for the `transactional server` role.
This PR adds this subvolume to the default list, so it is applied to all roles.

See the #197 for the Leap 15.2 counterpart or [bsc#1162320](https://bugzilla.suse.com/show_bug.cgi?id=1162320) for further information.