### PR TITLE
Update external link for non-x86 on Leap - bsc#1120938

### DIFF
--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Mar 20 08:23:19 UTC 2020 - Guillaume GARDET <guillaume.gardet@opensuse.org>
+
+- Update external link for non-x86 on Leap (bsc#1120938)
+- 20200320
+
+-------------------------------------------------------------------
 Thu Mar 12 16:16:57 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Add /boot/grub2/arm64-efi subvolume for all roles (bsc#1162320).

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        20200312
+Version:        20200320
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT
@@ -142,6 +142,7 @@ install -m 644 control/${CONTROL_FILE} $RPM_BUILD_ROOT%{?skelcdpath}/CD1/control
     sed -i -e "s,http://download.opensuse.org/update/tumbleweed/,http://download.opensuse.org/ports/$ports_arch/update/tumbleweed/," %{buildroot}%{?skelcdpath}/CD1/control.xml
     # Update external link
     sed -i -e "s,https://download.opensuse.org/YaST/Repos/openSUSE_Factory_Servers.xml,https://download.opensuse.org/YaST/Repos/openSUSE_$ports_arch\_Factory_Servers.xml," %{buildroot}%{?skelcdpath}/CD1/control.xml
+    sed -i -e "s,https://download.opensuse.org/YaST/Repos/openSUSE_Leap_,https://download.opensuse.org/YaST/Repos/openSUSE_$ports_arch\Leap_," %{buildroot}%{?skelcdpath}/CD1/control.xml
     #we parse out non existing non-oss repo for ports
     xsltproc -o %{buildroot}%{?skelcdpath}/CD1/control_ports.xml control/nonoss.xsl %{buildroot}%{?skelcdpath}/CD1/control.xml
     mv %{buildroot}%{?skelcdpath}/CD1/control{_ports,}.xml


### PR DESCRIPTION
This PR should fix https://bugzilla.opensuse.org/show_bug.cgi?id=1120938
Backport to `openSUSE-15_2` branch will follow.