### PR TITLE
Add release notes dependency

### DIFF
--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jun 25 10:49:55 UTC 2020 - José Iván López González <jlopez@suse.com>
+
+- Add release-notes dependency (bsc#1167866).
+- 20200625
+
+-------------------------------------------------------------------
 Wed May 13 12:40:28 UTC 2020 - Ludwig Nussel <lnussel@suse.de>
 
 - Require enhanced_base for serverro (poo#66105)

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        20200513
+Version:        20200625
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -91,6 +91,9 @@ Requires:       yast2-s390
 Requires:       yast2-vm
 %endif
 
+# Release notes should be part of the installation media (bsc#1167866)
+Requires:	release-notes
+
 %if 0%{?suse_version} >= 1500 && !0%{?skelcd_compat}
 %define skelcdpath /usr/lib/skelcd
 %endif


### PR DESCRIPTION
## Problem

*yast2-installation* does not recommend *release-notes* package anymore, see https://github.com/yast/yast-installation/pull/845. As a consequence,  release notes are not included in the installation media.

* https://bugzilla.suse.com/show_bug.cgi?id=1167866


## Solution

A dependency of *release-notes* package has been added to skelcd-control-openSUSE. Now, release notes would be available in the installation media but it would not be installed when *yast2-installation* is needed on the running system.
