### PR TITLE
Add Network Activation to update mode

### DIFF
--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -1059,6 +1059,10 @@ TODO: prepare disk here when it does not break space calculation (and remove bel
                     <retranslate config:type="boolean">true</retranslate>
                 </module>
                 <module>
+                    <label>Network Activation</label>
+                    <name>lan</name>
+                </module>
+                <module>
                     <label>Disk Activation</label>
                     <name>disks_activate</name>
                 </module>

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jul  6 09:40:19 UTC 2020 - José Iván López González <jlopez@suse.com>
+
+- Update mode: add Network Activation (bsc#1173676).
+- 15.2.4
+
+-------------------------------------------------------------------
 Fri Mar 20 08:23:19 UTC 2020 - Guillaume GARDET <guillaume.gardet@opensuse.org>
 
 - Update external link for non-x86 on Leap (bsc#1120938)

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        15.2.3
+Version:        15.2.4
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT


### PR DESCRIPTION
## Problem

During the upgrade mode, the option for configuring network is not offered. This option is specially useful to configure WIFI in laptops without a ethernet port.

* https://bugzilla.suse.com/show_bug.cgi?id=1173676

## Solution

Add missing step to update mode.
