### PR TITLE
Add Network Activation to update mode

### DIFF
--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -1070,6 +1070,10 @@ TODO: prepare disk here when it does not break space calculation (and remove bel
                     <retranslate config:type="boolean">true</retranslate>
                 </module>
                 <module>
+                    <label>Network Activation</label>
+                    <name>lan</name>
+                </module>
+                <module>
                     <label>Disk Activation</label>
                     <name>disks_activate</name>
                 </module>

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jul  6 09:56:47 UTC 2020 - José Iván López González <jlopez@suse.com>
+
+- Update mode: add Network Activation (bsc#1173676).
+- 20200706
+
+-------------------------------------------------------------------
 Wed Jul 01 13:50:11 UTC 2020 - Richard Brown <rbrown@suse.de>
 
 - Remove tmp subvolume for transactional systems [boo#1173461][jsc#PM-1898]

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        20200701
+Version:        20200706
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT


### PR DESCRIPTION
## Problem

During the upgrade mode, the option for configuring network is not offered. This option is specially useful to configure WIFI in laptops without a ethernet port.

* https://bugzilla.suse.com/show_bug.cgi?id=1173676

## Solution

Add missing step to update mode.

NOTE: this was also fixed for Leap 15.2, but too late, see https://github.com/yast/skelcd-control-openSUSE/pull/210.
