### PR TITLE
Remove /tmp subvolume

### DIFF
--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -240,9 +240,6 @@ textdomain="control"
                         <path>srv</path>
                     </subvolume>
                     <subvolume>
-                        <path>tmp</path>
-                    </subvolume>
-                    <subvolume>
                         <path>usr/local</path>
                     </subvolume>
                     <!-- unified var subvolume - https://lists.opensuse.org/opensuse-packaging/2017-11/msg00017.html -->
@@ -429,9 +426,6 @@ textdomain="control"
                         </subvolume>
                         <subvolume>
                             <path>srv</path>
-                        </subvolume>
-                        <subvolume>
-                            <path>tmp</path>
                         </subvolume>
                         <subvolume>
                             <path>boot/writable</path>

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jul 28 15:07:34 UTC 2020 - Richard Brown <rbrown@suse.de>
+
+- Remove tmp subvolume for all system roles [boo#1173461][jsc#PM-1898]
+- 20200728
+
+-------------------------------------------------------------------
 Tue Jul 07 11:07:34 UTC 2020 - Richard Brown <rbrown@suse.de>
 
 - Revert remove tmp subvolume for transactional systems [boo#1173461][jsc#PM-1898]

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        20200707
+Version:        20200728
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT


### PR DESCRIPTION
Changes to systemd and microos-tools are now on the way so this change is now safe/expected for everyone.

https://bugzilla.suse.com/show_bug.cgi?id=1173461