### PR TITLE
Removed unneeded AY installation step "autoimage" (bsc#1140711).

### DIFF
--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -1228,10 +1228,6 @@ TODO: prepare disk here when it does not break space calculation (and remove bel
                 </module>
                 <module>
                     <label>Perform Installation</label>
-                    <name>autoimage</name>
-                </module>
-                <module>
-                    <label>Perform Installation</label>
                     <name>rpmcopy</name>
                 </module>
                 <module>

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jul 29 10:59:21 CEST 2020 - schubi@suse.de
+
+- Removed unneeded AY installation step "autoimage" (bsc#1140711).
+- 20200729
+
+-------------------------------------------------------------------
 Tue Jul 07 11:07:34 UTC 2020 - Richard Brown <rbrown@suse.de>
 
 - Revert remove tmp subvolume for transactional systems [boo#1173461][jsc#PM-1898]

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        20200707
+Version:        20200729
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT


### PR DESCRIPTION
Note for the pull request authors:

The `master` branch is intended for the openSUSE Tumbleweed only,
if you want to have the same change in the openSUSE Leap then backport
it to the respective `openSUSE-X_Y` branch.

