### PR TITLE
Fix update external link for non-x86 on Leap - bsc#1120938

### DIFF
--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Nov  2 09:20:50 UTC 2020 - Guillaume GARDET <guillaume.gardet@opensuse.org>
+
+- Fix update external link for non-x86 on Leap (bsc#1120938)
+- 20201102
+
+-------------------------------------------------------------------
 Wed Oct  7 15:59:00 CEST 2020 - schubi@suse.de
 
 - Upgrade openSUSE->Jump. Allow vendor change without asking

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        20201007
+Version:        20201102
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT
@@ -148,7 +148,7 @@ install -m 644 control/${CONTROL_FILE} $RPM_BUILD_ROOT%{?skelcdpath}/CD1/control
     sed -i -e "s,http://download.opensuse.org/update/tumbleweed/,http://download.opensuse.org/ports/$ports_arch/update/tumbleweed/," %{buildroot}%{?skelcdpath}/CD1/control.xml
     # Update external link
     sed -i -e "s,https://download.opensuse.org/YaST/Repos/openSUSE_Factory_Servers.xml,https://download.opensuse.org/YaST/Repos/openSUSE_$ports_arch\_Factory_Servers.xml," %{buildroot}%{?skelcdpath}/CD1/control.xml
-    sed -i -e "s,https://download.opensuse.org/YaST/Repos/openSUSE_Leap_,https://download.opensuse.org/YaST/Repos/openSUSE_$ports_arch\Leap_," %{buildroot}%{?skelcdpath}/CD1/control.xml
+    sed -i -e "s,https://download.opensuse.org/YaST/Repos/openSUSE_Leap_,https://download.opensuse.org/YaST/Repos/openSUSE_$ports_arch\_Leap_," %{buildroot}%{?skelcdpath}/CD1/control.xml
     #we parse out non existing non-oss repo for ports
     xsltproc -o %{buildroot}%{?skelcdpath}/CD1/control_ports.xml control/nonoss.xsl %{buildroot}%{?skelcdpath}/CD1/control.xml
     mv %{buildroot}%{?skelcdpath}/CD1/control{_ports,}.xml


### PR DESCRIPTION
This fixes https://github.com/yast/skelcd-control-openSUSE/pull/201