### PR TITLE
Backport fix for 15.2 for aarch64 (bsc#1120938)

### DIFF
--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Oct  6 09:47:16 UTC 2020 - Guillaume GARDET <guillaume.gardet@opensuse.org>
+
+-  Fix update external link for non-x86 on Leap (bsc#1120938)
+- 15.2.5
+
+-------------------------------------------------------------------
 Mon Jul  6 09:40:19 UTC 2020 - José Iván López González <jlopez@suse.com>
 
 - Update mode: add Network Activation (bsc#1173676).

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        15.2.4
+Version:        15.2.5
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT
@@ -142,7 +142,7 @@ install -m 644 control/${CONTROL_FILE} $RPM_BUILD_ROOT%{?skelcdpath}/CD1/control
     sed -i -e "s,http://download.opensuse.org/update/tumbleweed/,http://download.opensuse.org/ports/$ports_arch/update/tumbleweed/," %{buildroot}%{?skelcdpath}/CD1/control.xml
     # Update external link
     sed -i -e "s,https://download.opensuse.org/YaST/Repos/openSUSE_Factory_Servers.xml,https://download.opensuse.org/YaST/Repos/openSUSE_$ports_arch\_Factory_Servers.xml," %{buildroot}%{?skelcdpath}/CD1/control.xml
-    sed -i -e "s,https://download.opensuse.org/YaST/Repos/openSUSE_Leap_,https://download.opensuse.org/YaST/Repos/openSUSE_$ports_arch\Leap_," %{buildroot}%{?skelcdpath}/CD1/control.xml
+    sed -i -e "s,https://download.opensuse.org/YaST/Repos/openSUSE_Leap_,https://download.opensuse.org/YaST/Repos/openSUSE_$ports_arch\_Leap_," %{buildroot}%{?skelcdpath}/CD1/control.xml
     #we parse out non existing non-oss repo for ports
     xsltproc -o %{buildroot}%{?skelcdpath}/CD1/control_ports.xml control/nonoss.xsl %{buildroot}%{?skelcdpath}/CD1/control.xml
     mv %{buildroot}%{?skelcdpath}/CD1/control{_ports,}.xml


### PR DESCRIPTION
Fixes https://github.com/yast/skelcd-control-openSUSE/pull/203 by backporting https://github.com/yast/skelcd-control-openSUSE/pull/215