### PR TITLE
Upgrade openSUSE->Jump. Allow vendor change without asking the user. …

### DIFF
--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -185,15 +185,26 @@ textdomain="control"
                     <install_patterns>lxde</install_patterns>
                 </window_manager>
             </window_managers>
-            <!-- Do not ask for vendor change during this defined upgrade -->
-            <product_upgrade>
-                <from>openSUSE Leap</from>
-                <to>openSUSE Jump 15.2.1</to>
-                <compatible_vendors config:type="list">
-                  <compatible_vendor>openSUSE</compatible_vendor>
-                  <compatible_vendor>SUSE LLC</compatible_vendor>
-                </compatible_vendors>
-             </product_upgrade>
+            <!-- Do not ask for vendor change during this defined upgrades -->
+            <product_upgrades config:type="list">
+                <product_upgrade>
+                    <from>openSUSE Leap</from>
+                    <to>openSUSE Jump</to>
+                    <compatible_vendors config:type="list">
+                      <compatible_vendor>openSUSE</compatible_vendor>
+                      <compatible_vendor>SUSE LLC</compatible_vendor>
+                    </compatible_vendors>
+                </product_upgrade>
+	        <!-- Remove this entry when bsc#1177443 has been fixed -->
+                <product_upgrade>
+                    <from>openSUSE Leap</from>
+                    <to>openSUSE Jump 15.2.1</to>
+                    <compatible_vendors config:type="list">
+                      <compatible_vendor>openSUSE</compatible_vendor>
+                      <compatible_vendor>SUSE LLC</compatible_vendor>
+                    </compatible_vendors>
+                </product_upgrade>
+	    </product_upgrades>
         </upgrade>
         <!-- boo#1124590 - Ensure correct product is selected -->
         <select_product>openSUSE</select_product>

--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -185,6 +185,15 @@ textdomain="control"
                     <install_patterns>lxde</install_patterns>
                 </window_manager>
             </window_managers>
+            <!-- Do not ask for vendor change during this defined upgrade -->
+            <product_upgrade>
+                <from>openSUSE Leap</from>
+                <to>openSUSE Jump 15.2.1</to>
+                <compatible_vendors config:type="list">
+                  <compatible_vendor>openSUSE</compatible_vendor>
+                  <compatible_vendor>SUSE LLC</compatible_vendor>
+                </compatible_vendors>
+             </product_upgrade>
         </upgrade>
         <!-- boo#1124590 - Ensure correct product is selected -->
         <select_product>openSUSE</select_product>

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -3,7 +3,7 @@ Wed Oct  7 15:59:00 CEST 2020 - schubi@suse.de
 
 - Upgrade openSUSE->Jump. Allow vendor change without asking
   the user. Added "product_upgrade" tag in software/upgrade.
-  (jsc#SLE-15184)
+  (jsc#SLE-14807)
 - 20201007
 
 -------------------------------------------------------------------

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Oct  7 15:59:00 CEST 2020 - schubi@suse.de
+
+- Upgrade openSUSE->Jump. Allow vendor change without asking
+  the user. Added "product_upgrade" tag in software/upgrade.
+  (jsc#SLE-15184)
+- 20201007
+
+-------------------------------------------------------------------
 Thu Jul 30 16:57:34 UTC 2020 - Richard Brown <rbrown@suse.de>
 
 - Remove tmp subvolume for all system roles [boo#1173461][jsc#PM-1898]

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -2,7 +2,7 @@
 Wed Oct  7 15:59:00 CEST 2020 - schubi@suse.de
 
 - Upgrade openSUSE->Jump. Allow vendor change without asking
-  the user. Added "product_upgrade" tag in software/upgrade.
+  the user. Added "product_upgrades" tag in software/upgrade.
   (jsc#SLE-14807)
 - 20201007
 

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        20200730
+Version:        20201007
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -41,7 +41,7 @@ BuildRequires:  libxml2-tools
 # xsltproc
 BuildRequires:  libxslt-tools
 # RNG schema
-BuildRequires:  yast2-installation-control >= 4.0.10
+BuildRequires:  yast2-installation-control >= 4.3.6
 ######################################################################
 #
 # Here is the list of Yast packages which are needed in the


### PR DESCRIPTION
…Added "product_upgrade" tag in software/upgrade.

Note for the pull request authors:

The `master` branch is intended for the openSUSE Tumbleweed only,
if you want to have the same change in the openSUSE Leap then backport
it to the respective `openSUSE-X_Y` branch.

