### PR TITLE
Upgrade openSUSE->Jump. Allow vendor change without asking the user.

### DIFF
--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -191,15 +191,26 @@ textdomain="control"
                     <install_patterns>lxde</install_patterns>
                 </window_manager>
             </window_managers>
-            <!-- Do not ask for vendor change during this defined upgrade -->
-            <product_upgrade>
-                <from>openSUSE Leap</from>
-                <to>openSUSE Jump 15.2.1</to>
-                <compatible_vendors config:type="list">
-                  <compatible_vendor>openSUSE</compatible_vendor>
-                  <compatible_vendor>SUSE LLC</compatible_vendor>
-                </compatible_vendors>
-             </product_upgrade>
+            <!-- Do not ask for vendor change during this defined upgrades -->
+            <product_upgrades config:type="list">
+                <product_upgrade>
+                    <from>openSUSE Leap</from>
+                    <to>openSUSE Jump</to>
+                    <compatible_vendors config:type="list">
+                      <compatible_vendor>openSUSE</compatible_vendor>
+                      <compatible_vendor>SUSE LLC</compatible_vendor>
+                    </compatible_vendors>
+                </product_upgrade>
+	        <!-- Remove this entry when bsc#1177443 has been fixed -->
+                <product_upgrade>
+                    <from>openSUSE Leap</from>
+                    <to>openSUSE Jump 15.2.1</to>
+                    <compatible_vendors config:type="list">
+                      <compatible_vendor>openSUSE</compatible_vendor>
+                      <compatible_vendor>SUSE LLC</compatible_vendor>
+                    </compatible_vendors>
+                </product_upgrade>
+	    </product_upgrades>
         </upgrade>
 
     </software>

--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -191,6 +191,15 @@ textdomain="control"
                     <install_patterns>lxde</install_patterns>
                 </window_manager>
             </window_managers>
+            <!-- Do not ask for vendor change during this defined upgrade -->
+            <product_upgrade>
+                <from>openSUSE Leap</from>
+                <to>openSUSE Jump 15.2.1</to>
+                <compatible_vendors config:type="list">
+                  <compatible_vendor>openSUSE</compatible_vendor>
+                  <compatible_vendor>SUSE LLC</compatible_vendor>
+                </compatible_vendors>
+             </product_upgrade>
         </upgrade>
 
     </software>

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -2,7 +2,7 @@
 Wed Oct  7 15:59:00 CEST 2020 - schubi@suse.de
 
 - Upgrade openSUSE->Jump. Allow vendor change without asking
-  the user. Added "product_upgrade" tag in software/upgrade.
+  the user. Added "product_upgrades" tag in software/upgrade.
   (jsc#SLE-14807)
 - 15.2.6
 

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,7 +1,15 @@
 -------------------------------------------------------------------
+Wed Oct  7 15:59:00 CEST 2020 - schubi@suse.de
+
+- Upgrade openSUSE->Jump. Allow vendor change without asking
+  the user. Added "product_upgrade" tag in software/upgrade.
+  (jsc#SLE-15184)
+- 15.2.6
+
+-------------------------------------------------------------------
 Tue Oct  6 09:47:16 UTC 2020 - Guillaume GARDET <guillaume.gardet@opensuse.org>
 
--  Fix update external link for non-x86 on Leap (bsc#1120938)
+- Fix update external link for non-x86 on Leap (bsc#1120938)
 - 15.2.5
 
 -------------------------------------------------------------------

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -3,7 +3,7 @@ Wed Oct  7 15:59:00 CEST 2020 - schubi@suse.de
 
 - Upgrade openSUSE->Jump. Allow vendor change without asking
   the user. Added "product_upgrade" tag in software/upgrade.
-  (jsc#SLE-15184)
+  (jsc#SLE-14807)
 - 15.2.6
 
 -------------------------------------------------------------------

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -41,7 +41,7 @@ BuildRequires:  libxml2-tools
 # xsltproc
 BuildRequires:  libxslt-tools
 # RNG schema
-BuildRequires:  yast2-installation-control >= 4.3.6
+BuildRequires:  yast2-installation-control >= 4.2.10
 ######################################################################
 #
 # Here is the list of Yast packages which are needed in the

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -41,7 +41,7 @@ BuildRequires:  libxml2-tools
 # xsltproc
 BuildRequires:  libxslt-tools
 # RNG schema
-BuildRequires:  yast2-installation-control >= 4.0.10
+BuildRequires:  yast2-installation-control >= 4.3.6
 ######################################################################
 #
 # Here is the list of Yast packages which are needed in the

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        15.2.5
+Version:        15.2.6
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT


### PR DESCRIPTION
It is a backport from 
https://github.com/yast/skelcd-control-openSUSE/pull/218