### PR TITLE
AY: write linuxrc proxy and hostname to inst-sys

### DIFF
--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -1170,6 +1170,11 @@ TODO: prepare disk here when it does not break space calculation (and remove bel
                 <enable_next>no</enable_next>
             </defaults>
             <modules config:type="list">
+                <module>
+                    <!-- writes hostname and proxy config bsc#1177768 -->
+                    <label>Load Linuxrc Network Configuration</label>
+                    <name>install_inf</name>
+                </module>
                 <!-- As soon as possible -->
                 <module>
                     <label>Installer Update</label>

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Oct 30 08:21:02 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Write linuxrc hostname and proxy configuration also during an
+  autoinstallation (bsc#1177768)
+- 15.2.7
+
+-------------------------------------------------------------------
 Wed Oct  7 15:59:00 CEST 2020 - schubi@suse.de
 
 - Upgrade openSUSE->Jump. Allow vendor change without asking

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        15.2.6
+Version:        15.2.7
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT


### PR DESCRIPTION
## Problem

During an autoinstallation, if the networking section only contains the [keep_install_network](https://doc.opensuse.org/projects/autoyast/#CreateProfile-Network) option it should copy the network configuration from linuxrc to the target system. This is not the case of the hostname option which is lost.

- https://bugzilla.suse.com/show_bug.cgi?id=1177768

## Solution

Add the install_inf client to be run also in autoinstallation (see https://github.com/yast/yast-installation/pull/893)

