### PR TITLE
Do not update repo paths for Leap 15.3 and later

### DIFF
--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Nov  6 09:04:28 UTC 2020 - Guillaume GARDET <guillaume.gardet@opensuse.org>
+
+- Do not update repo paths for Leap 15.3 and later as all supported
+  archs are built in the same project and published in the same
+  online directory
+- 20201106
+
+-------------------------------------------------------------------
 Wed Nov  4 15:16:59 UTC 2020 - Stasiek Michalski <hellcp@mailbox.org>
 
 - Adjust the roles to the new YaST Patterns (boo#1159875)

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -124,6 +124,8 @@ make %{?_smp_mflags} -C control check
 mkdir -p $RPM_BUILD_ROOT%{?skelcdpath}/CD1
 install -m 644 control/${CONTROL_FILE} $RPM_BUILD_ROOT%{?skelcdpath}/CD1/control.xml
 
+%if 0%{?sle_version} <= 150200
+# With Leap 15.3 and later, all supported archs are in the same repo. TW remains separated.
 %ifarch aarch64 %arm ppc ppc64 ppc64le s390x
     ports_arch="%{_arch}"
     %ifarch ppc ppc64 ppc64le
@@ -153,6 +155,7 @@ install -m 644 control/${CONTROL_FILE} $RPM_BUILD_ROOT%{?skelcdpath}/CD1/control
     xsltproc -o %{buildroot}%{?skelcdpath}/CD1/control_ports.xml control/nonoss.xsl %{buildroot}%{?skelcdpath}/CD1/control.xml
     mv %{buildroot}%{?skelcdpath}/CD1/control{_ports,}.xml
     xmllint --noout --relaxng %{_datadir}/YaST2/control/control.rng %{buildroot}%{?skelcdpath}/CD1/control.xml
+%endif
 %endif
 
 %files


### PR DESCRIPTION
 as all supported archs are built in the same project and published in the same online directory.