### PR TITLE
[Leap 15.3] Set SELinux permissive mode by default

### DIFF
--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -70,6 +70,12 @@ textdomain="control"
         <!-- FATE: #303893, #305588: Default to enabled kdump -->
         <enable_kdump config:type="boolean">true</enable_kdump>
 
+        <!-- Set SELinux permissive mode by default, https://github.com/yast/yast-installation/pull/906#issuecomment-784238549 -->
+        <selinux>
+          <mode>disabled</mode>
+          <configurable config:type="boolean">true</configurable>
+        </selinux>
+
         <!-- to debug deploying, set to 'true' -->
         <debug_deploying config:type="boolean">false</debug_deploying>
     </globals>

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Feb 24 09:06:46 UTC 2021 - David Diaz <dgonzalez@suse.com>
+
+- Set SELinux disabled mode by default (related to jsc#SLE-17307)
+- 15.3.1
+
+-------------------------------------------------------------------
 Fri Feb 12 16:49:22 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - Adapt the package for openSUSE Leap 15.3

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        15.3.0
+Version:        15.3.1
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT


### PR DESCRIPTION
Related to feature https://jira.suse.com/browse/SLE-17307 (internal link), sets SELinux as a major [**L**inux **S**ecurity **M**odule](https://www.kernel.org/doc/html/latest/admin-guide/LSM/index.html) in its ~~permissive~~ **disabled** mode in spite of the requested at https://github.com/yast/yast-installation/pull/906#issuecomment-784238549  (see https://github.com/yast/skelcd-control-openSUSE/pull/227#discussion_r583534726) .

For openSUSE Tumbleweed, see https://github.com/yast/skelcd-control-openSUSE/pull/228

--- 

Related to https://github.com/yast/yast-security/pull/87 and https://github.com/yast/yast-installation/pull/906