### PR TITLE
[Tumbleweed] Set SELinux permissive mode by default

### DIFF
--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -70,6 +70,13 @@ textdomain="control"
         <!-- FATE: #303893, #305588: Default to enabled kdump -->
         <enable_kdump config:type="boolean">true</enable_kdump>
 
+        <!-- Set SELinux permissive mode by default, https://github.com/yast/yast-installation/pull/906#issuecomment-784238549 -->
+        <selinux>
+          <mode>permissive</mode>
+          <configurable config:type="boolean">true</configurable>
+          <patterns>selinux</patterns>
+        </selinux>
+
         <!-- to debug deploying, set to 'true' -->
         <debug_deploying config:type="boolean">false</debug_deploying>
     </globals>

--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -658,9 +658,9 @@ configured accordingly to match the use case of the role. &lt;/p&gt;</label>
                     <name>default_target</name>
                     <presentation_order>70</presentation_order>
                 </proposal_module>
-                <!-- FaTE #303859 - simple network (in fact firewall) cfg in 1st stage -->
+                <!-- security proposal including firewall, cpu mitigation, selinux and polkit -->
                 <proposal_module>
-                    <name>firewall</name>
+                    <name>security</name>
                     <presentation_order>95</presentation_order>
                 </proposal_module>
                 <!-- Fate #319624 - proposal and dialog for existing SSH host keys -->
@@ -720,7 +720,7 @@ configured accordingly to match the use case of the role. &lt;/p&gt;</label>
                     <presentation_order>75</presentation_order>
                 </proposal_module>
                 <proposal_module>
-                    <name>firewall</name>
+                    <name>security</name>
                     <presentation_order>50</presentation_order>
                 </proposal_module>
                 <proposal_module>
@@ -773,9 +773,8 @@ configured accordingly to match the use case of the role. &lt;/p&gt;</label>
                     <name>default_target</name>
                     <presentation_order>70</presentation_order>
                 </proposal_module>
-                <!-- FaTE #303859 - simple network (in fact firewall) cfg in 1st stage -->
                 <proposal_module>
-                    <name>firewall</name>
+                    <name>security</name>
                     <presentation_order>99</presentation_order>
                 </proposal_module>
                 <!-- Fate #319624 - proposal and dialog for existing SSH host keys -->

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Feb 24 09:18:25 UTC 2021 - David Diaz <dgonzalez@suse.com>
+
+- Set SELinux permissive mode by default (related to jsc#SLE-17307)
+- 20210224
+
+-------------------------------------------------------------------
 Tue Nov  10 04:59:22 UTC 2020 - Simon Lees <sflees@suse.de>
 
 - Server Role should install the new yast2_server pattern

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        20201110
+Version:        20210224
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT


### PR DESCRIPTION
Related to feature https://jira.suse.com/browse/SLE-17307 (internal link), sets SELinux as a major [**L**inux **S**ecurity **M**odule](https://www.kernel.org/doc/html/latest/admin-guide/LSM/index.html) in its permissive mode, as requested at https://github.com/yast/yast-installation/pull/906#issuecomment-784238549.

For openSUSE Leap, see https://github.com/yast/skelcd-control-openSUSE/pull/227

--- 

Related to https://github.com/yast/yast-security/pull/87 and https://github.com/yast/yast-installation/pull/906