### PR TITLE
Selinux change

### DIFF
--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -72,7 +72,7 @@ textdomain="control"
 
         <!-- Set SELinux permissive mode by default, https://github.com/yast/yast-installation/pull/906#issuecomment-784238549 -->
         <selinux>
-          <mode>permissive</mode>
+          <mode>disabled</mode>
           <configurable config:type="boolean">true</configurable>
           <patterns>selinux</patterns>
         </selinux>

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Mar 16 15:51:39 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
+
+- Set SELinux disabled by default (bsc#1183583)
+- 20210316
+
+-------------------------------------------------------------------
 Wed Feb 24 09:18:25 UTC 2021 - David Diaz <dgonzalez@suse.com>
 
 - Set SELinux permissive mode by default (related to jsc#SLE-17307)

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        20210224
+Version:        20210316
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT


### PR DESCRIPTION
bsc: https://bugzilla.suse.com/show_bug.cgi?id=1183583

basically selinux is not ready to be enabled by default and also it changes behavior as it by default disable apparmor.

