### PR TITLE
Fix security proposal

### DIFF
--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -648,6 +648,12 @@ configured accordingly to match the use case of the role. &lt;/p&gt;</label>
                     <name>hwinfo</name>
                     <presentation_order>80</presentation_order>
                 </proposal_module>
+                <!-- security proposal including firewall, cpu mitigation, selinux and polkit -->
+                <!-- It adds to software proposal, so it needs to above of it and it needs to be below bootloader to modify it -->
+                <proposal_module>
+                    <name>security</name>
+                    <presentation_order>95</presentation_order>
+                </proposal_module>
                 <!-- software proposal should be computed almost at the end -->
                 <proposal_module>
                     <name>software</name>
@@ -657,11 +663,6 @@ configured accordingly to match the use case of the role. &lt;/p&gt;</label>
         <!-- propose the default runlevel after software is selected, bnc #380141 -->
                     <name>default_target</name>
                     <presentation_order>70</presentation_order>
-                </proposal_module>
-                <!-- security proposal including firewall, cpu mitigation, selinux and polkit -->
-                <proposal_module>
-                    <name>security</name>
-                    <presentation_order>95</presentation_order>
                 </proposal_module>
                 <!-- Fate #319624 - proposal and dialog for existing SSH host keys -->
                 <proposal_module>
@@ -709,6 +710,10 @@ configured accordingly to match the use case of the role. &lt;/p&gt;</label>
                     <name>kdump</name>
                     <presentation_order>60</presentation_order>
                 </proposal_module>
+                <proposal_module>
+                    <name>security</name>
+                    <presentation_order>50</presentation_order>
+                </proposal_module>
                 <!-- software proposal should be computed almost at the end -->
                 <proposal_module>
                     <name>software</name>
@@ -718,10 +723,6 @@ configured accordingly to match the use case of the role. &lt;/p&gt;</label>
                 <proposal_module>
                     <name>default_target</name>
                     <presentation_order>75</presentation_order>
-                </proposal_module>
-                <proposal_module>
-                    <name>security</name>
-                    <presentation_order>50</presentation_order>
                 </proposal_module>
                 <proposal_module>
                     <name>network</name>
@@ -763,6 +764,10 @@ configured accordingly to match the use case of the role. &lt;/p&gt;</label>
                     <name>hwinfo</name>
                     <presentation_order>80</presentation_order>
                 </proposal_module>
+                <proposal_module>
+                    <name>security</name>
+                    <presentation_order>99</presentation_order>
+                </proposal_module>
                 <!-- software proposal should be computed almost at the end -->
                 <proposal_module>
                     <name>software</name>
@@ -772,10 +777,6 @@ configured accordingly to match the use case of the role. &lt;/p&gt;</label>
                 <proposal_module>
                     <name>default_target</name>
                     <presentation_order>70</presentation_order>
-                </proposal_module>
-                <proposal_module>
-                    <name>security</name>
-                    <presentation_order>99</presentation_order>
                 </proposal_module>
                 <!-- Fate #319624 - proposal and dialog for existing SSH host keys -->
                 <proposal_module>

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Mar 29 09:07:18 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
+
+- Respect additional software needed by security proposal
+  (bsc#1183804)
+- 20210329
+
+-------------------------------------------------------------------
 Tue Mar 16 15:51:39 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
 
 - Set SELinux disabled by default (bsc#1183583)

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        20210316
+Version:        20210329
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT


### PR DESCRIPTION
bsc: https://bugzilla.suse.com/show_bug.cgi?id=1183804

Issue is that security module adds selinux pattern if selinux is enabled, but it is after software proposal is computed. So it is shown only after recompute of proposal that does not need to happen. So move security upper.

