### PR TITLE
Fix boo#1182915 - add repo-debug-update to Leap 15.3

### DIFF
--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -137,6 +137,12 @@ textdomain="control"
                 <enabled config:type="boolean">false</enabled>
             </extra_url>
             <extra_url>
+                <baseurl>http://download.opensuse.org/debug/update/leap/$releasever/oss/</baseurl>
+                <alias>repo-debug-update</alias>
+                <name>Update Repository (Debug)</name>
+                <enabled config:type="boolean">false</enabled>
+            </extra_url>
+            <extra_url>
                 <baseurl>http://download.opensuse.org/debug/distribution/leap/$releasever/repo/non-oss/</baseurl>
                 <alias>repo-debug-non-oss</alias>
                 <name>Debug Repository (Non-OSS)</name>

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        15.3.2
+Version:        15.3.3
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT


### PR DESCRIPTION
* supply update-debug repository

Note for the pull request authors:

The `master` branch is intended for the openSUSE Tumbleweed only,
if you want to have the same change in the openSUSE Leap then backport
it to the respective `openSUSE-X_Y` branch.

