### PR TITLE
Upgrade manual network activation

### DIFF
--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -1097,6 +1097,10 @@ TODO: prepare disk here when it does not break space calculation (and remove bel
                     <retranslate config:type="boolean">true</retranslate>
                 </module>
                 <module>
+                    <label>Network Activation</label>
+                    <name>lan</name>
+                </module>
+                <module>
                     <label>Disk Activation</label>
                     <name>disks_activate</name>
                 </module>

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jul 27 08:52:36 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- During upgrade run also the manual network configuration when it
+  is not configured automatically (bsc#1188689).
+- 15.4.2
+
+-------------------------------------------------------------------
 Wed May  5 13:40:25 UTC 2021 - Guillaume GARDET <guillaume.gardet@opensuse.org>
 
 - Fix path of repo for Leap 15.3+ armv7 (boo#1183795)

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        15.4.1
+Version:        15.4.2
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT


### PR DESCRIPTION
## Problem

In openSUSE, the manual network configuration is not part of the upgrade workflow which means that in case of no network it is tricky to setup it during the upgrade.

- https://bugzilla.suse.com/show_bug.cgi?id=1188689

## Solution

Add the network client as it is already for [SLES/SLED](https://github.com/yast/skelcd-control-leanos/blob/master/control/control.leanos.xml#L643)
