### PR TITLE
Update Rakefile for Leap15.3 updates

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@ require "yast/rake"
 Yast::Tasks.configuration do |conf|
   conf.obs_api = "https://api.opensuse.org"
   conf.obs_target = "openSUSE_Leap_15.3"
-  conf.obs_sr_project = "openSUSE:Leap:15.3"
+  conf.obs_sr_project = "openSUSE:Leap:15.3:Update"
   conf.obs_project = "YaST:openSUSE:15.3"
   #lets ignore license check for now
   conf.skip_license_check << /.*/


### PR DESCRIPTION
Submit openSUSE 15.3 changes to `openSUSE:Leap:15.3:Update`.

Already submitted manually by https://build.opensuse.org/request/show/908856

