### PR TITLE
Define default NTP servers for Leap (bsc#1180699)

### DIFF
--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -47,6 +47,14 @@ textdomain="control"
         <show_addons config:type="boolean">true</show_addons>
         <addons_default config:type="boolean">false</addons_default>
 
+        <!-- #1180699: Use openSUSE default NTP servers instead of SUSE ones -->
+        <default_ntp_servers config:type="list">
+          <ntp_server>0.opensuse.pool.ntp.org</ntp_server>
+          <ntp_server>1.opensuse.pool.ntp.org</ntp_server>
+          <ntp_server>2.opensuse.pool.ntp.org</ntp_server>
+          <ntp_server>3.opensuse.pool.ntp.org</ntp_server>
+        </default_ntp_servers>
+
         <!-- FATE #301937, Save /root content from the installation system to the installed system -->
         <save_instsys_content config:type="list">
             <save_instsys_item>

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Sep  7 14:14:29 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- Define default NTP servers for Leap (bsc#1180699)
+- 20210907
+
+-------------------------------------------------------------------
 Tue Jul 27 08:52:36 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - During upgrade run also the manual network configuration when it

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        15.4.2
+Version:        15.4.3
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT
@@ -41,7 +41,7 @@ BuildRequires:  libxml2-tools
 # xsltproc
 BuildRequires:  libxslt-tools
 # RNG schema
-BuildRequires:  yast2-installation-control >= 4.3.6
+BuildRequires:  yast2-installation-control >= 4.4.3
 ######################################################################
 #
 # Here is the list of Yast packages which are needed in the


### PR DESCRIPTION
Similar to https://github.com/yast/skelcd-control-openSUSE/pull/223 but for Leap 15.3

