### PR TITLE
Add backports-update, backports-debug-update, sle-update and sle-debug-update to control file

### DIFF
--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -116,6 +116,30 @@ textdomain="control"
                 <name>Update Repository (Non-Oss)</name>
                 <enabled config:type="boolean">true</enabled>
             </extra_url>
+            <extra_url>
+                <baseurl>http://download.opensuse.org/update/leap/$releasever/backports/</baseurl>
+                <alias>repo-backports-update</alias>
+                <name>Update repository of openSUSE Backports</name>
+                <enabled config:type="boolean">true</enabled>
+            </extra_url>
+            <extra_url>
+                <baseurl>http://download.opensuse.org/update/leap/$releasever/backports_debug/</baseurl>
+                <alias>repo-backports-debug-update</alias>
+                <name>Update repository of openSUSE Backports (Debug)</name>
+                <enabled config:type="boolean">false</enabled>
+            </extra_url>
+            <extra_url>
+                <baseurl>http://download.opensuse.org/update/leap/$releasever/sle/</baseurl>
+                <alias>repo-sle-update</alias>
+                <name>Update repository with updates from SUSE Linux Enterprise 15</name>
+                <enabled config:type="boolean">true</enabled>
+            </extra_url>
+            <extra_url>
+                <baseurl>http://download.opensuse.org/debug/update/leap/$releasever/sle/</baseurl>
+                <alias>repo-sle-debug-update</alias>
+                <name>Update repository with updates from SUSE Linux Enterprise 15 (Debug)</name>
+                <enabled config:type="boolean">false</enabled>
+            </extra_url>
 
             <!-- Replacement for EXTRAURLS and OPTIONALURLS -->
             <extra_url>

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Oct  5 05:46:51 UTC 2021 - Max Lin <mlin@suse.com>
+
+- Add backports-update, backports-debug-update, sle-update and
+  sle-debug-update to control file (bsc#1186593)
+- 15.3.6
+
+-------------------------------------------------------------------
 Tue Jul 27 13:05:15 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - During upgrade run also the manual network configuration when it

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        15.3.5
+Version:        15.3.6
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT


### PR DESCRIPTION
While respining Leap 15.3 we should fix this issue in skelcd-control and removing the workaround from the release package bsc#1186593 . Please do not submit this to `openSUSE:Leap:15.3:Updat`e, this should be stricts to Leap 15.3 respin only, `:Update` project should not accept/publish any skelcd-control change though.

