### PR TITLE
Added new 'lsm' section for selecting the desired Linux Security Module during installation

### DIFF
--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -79,11 +79,23 @@ textdomain="control"
         <enable_kdump config:type="boolean">true</enable_kdump>
 
         <!-- Set SELinux permissive mode by default, https://github.com/yast/yast-installation/pull/906#issuecomment-784238549 -->
-        <selinux>
-          <mode>disabled</mode>
+        <lsm>
+          <default>apparmor</default>
+          <!-- Set SELinux disabled mode by default -->
+          <apparmor>
+            <patterns>apparmor</patterns>
+            <selectable config:type="boolean">true</selectable>
+          </apparmor>
+          <selinux>
+            <!-- Set SELinux enforcing mode by default -->
+            <mode>enforcing</mode>
+            <configurable config:type="boolean">true</configurable>
+            <selectable config:type="boolean">true</selectable>
+            <patterns>selinux</patterns>
+          </selinux>
           <configurable config:type="boolean">true</configurable>
-          <patterns>selinux</patterns>
-        </selinux>
+        </lsm>
+
 
         <!-- to debug deploying, set to 'true' -->
         <debug_deploying config:type="boolean">false</debug_deploying>

--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -78,17 +78,15 @@ textdomain="control"
         <!-- FATE: #303893, #305588: Default to enabled kdump -->
         <enable_kdump config:type="boolean">true</enable_kdump>
 
-        <!-- Set SELinux permissive mode by default, https://github.com/yast/yast-installation/pull/906#issuecomment-784238549 -->
         <lsm>
-          <default>apparmor</default>
-          <!-- Set SELinux disabled mode by default -->
+          <select>apparmor</select>
           <apparmor>
             <patterns>apparmor</patterns>
             <selectable config:type="boolean">true</selectable>
           </apparmor>
+          <!-- Set SELinux permissive mode by default, https://github.com/yast/yast-installation/pull/906#issuecomment-784238549 -->
           <selinux>
-            <!-- Set SELinux enforcing mode by default -->
-            <mode>enforcing</mode>
+            <mode>permissive</mode>
             <configurable config:type="boolean">true</configurable>
             <selectable config:type="boolean">true</selectable>
             <patterns>selinux</patterns>

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Dec 27 17:29:08 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- Added 'lsm' section for selecting and configuring the desired
+  Linux Security Module (jsc#SLE-22069)
+- 20211227
+
+-------------------------------------------------------------------
 Mon Sep  6 09:44:46 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
 
 - Define default ntp servers (bsc#1180699)

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        20210906
+Version:        20211227
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT
@@ -40,8 +40,8 @@ Source99:       README.md
 BuildRequires:  libxml2-tools
 # xsltproc
 BuildRequires:  libxslt-tools
-# RNG schema
-BuildRequires:  yast2-installation-control >= 4.4.3
+# Added 'lsm' section (jsc#SLE-22069)
+BuildRequires:  yast2-installation-control >= 4.4.7
 ######################################################################
 #
 # Here is the list of Yast packages which are needed in the


### PR DESCRIPTION
For more info, see https://github.com/yast/yast-security/pull/115 and https://github.com/yast/yast-installation/pull/1006

---

Note for the pull request authors:

The `master` branch is intended for the openSUSE Tumbleweed only,
if you want to have the same change in the openSUSE Leap then backport
it to the respective `openSUSE-X_Y` branch.

