### PR TITLE
Use NetworkManager always

### DIFF
--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -363,8 +363,7 @@ textdomain="control"
     </partitioning>
 
     <network>
-        <force_static_ip config:type="boolean">false</force_static_ip>
-        <startmode>ifplugd</startmode>
+        <network_manager>always</network_manager>
     </network>
 
     <system_roles config:type="list">
@@ -372,9 +371,6 @@ textdomain="control"
         <!-- the id is a key for texts/$id/label
                              and texts/$id_description/label below -->
         <id>kde</id>
-        <network>
-          <network_manager>always</network_manager>
-        </network>
         <software>
           <default_patterns>kde x11 base enhanced_base x11_yast yast2_basis</default_patterns>
         </software>
@@ -384,9 +380,6 @@ textdomain="control"
 
       <system_role>
         <id>gnome</id>
-        <network>
-          <network_manager>always</network_manager>
-        </network>
         <software>
           <default_patterns>gnome x11 base enhanced_base x11_yast yast2_basis</default_patterns>
         </software>
@@ -395,9 +388,6 @@ textdomain="control"
 
       <system_role>
         <id>xfce</id>
-        <network>
-          <network_manager>always</network_manager>
-        </network>
         <software>
           <default_patterns>xfce x11 base enhanced_base x11_yast yast2_basis</default_patterns>
         </software>

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jan 19 12:48:38 UTC 2022 - Ludwig Nussel <lnussel@suse.de>
+
+- Use NetworkManager always
+- 20220119
+
+-------------------------------------------------------------------
 Mon Dec 27 17:29:08 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - Added 'lsm' section for selecting and configuring the desired

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        20211227
+Version:        20220121
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT


### PR DESCRIPTION
Wicked lacks caretaking in Tumbleweed and is just slow to boot.
NetworkManager is good enough also for most common server use cases
in Tumbleweed so let's just use one technology for all roles.

YaST anyway allows to switch to wicked in the proposal screen. So those
who know that they need for advanced cases wicked can still have it.

