### PR TITLE
Added "kdump" dependency

### DIFF
--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Jul 26 14:27:02 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Added "kdump" dependency, yast2-kdump only has a runtime
+  depenency but the package is also needed in the inst-sys
+  (related to bsc#1199840)
+- 20220726
+
+-------------------------------------------------------------------
 Wed Jan 19 12:48:38 UTC 2022 - Ludwig Nussel <lnussel@suse.de>
 
 - Use NetworkManager always (boo#1172684)

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -22,12 +22,12 @@
 #   in build service directly, use
 #   https://github.com/yast/skelcd-control-openSUSE repository
 #
-#   See https://github.com/yast/skelcd-control-openSUSE/blob/master/CONTRIBUTING.md
+#   See https://github.com/yast/.github/blob/master/CONTRIBUTING.md
 #   for more details.
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        20220119
+Version:        20220726
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT
@@ -59,6 +59,8 @@ Requires:       yast2-firewall
 Requires:       yast2-installation >= 3.1.201
 Requires:       yast2-iscsi-client
 Requires:       yast2-kdump
+# yast2-kdump has only runtime dependency but the package is also needed in the inst-sys
+Requires:       kdump
 Requires:       yast2-multipath
 Requires:       yast2-network >= 3.1.24
 Requires:       yast2-nfs-client


### PR DESCRIPTION
- Related to https://github.com/yast/yast-kdump/pull/128, `yast2-kdump` now uses a runtime dependency
- But we also need the `kdump` package in the inst-sys ([bsc#875765#c4](https://bugzilla.suse.com/show_bug.cgi?id=875765#c4))
- So add it explicitly here