### PR TITLE
more accurate name and description of graphical system roles

### DIFF
--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -605,26 +605,26 @@ configured accordingly to match the use case of the role. &lt;/p&gt;</label>
         </roles_help>
         <kde>
           <!-- TRANSLATORS: a label for a system role -->
-          <label>Full desktop with KDE Plasma</label>
+          <label>Desktop with KDE Plasma</label>
         </kde>
         <kde_description>
-	  <label>Complete graphical system with KDE Plasma as desktop environment. Suitable for Workstations, Desktops and Laptops.
+	  <label>Graphical system with KDE Plasma as desktop environment and additional set of software. Suitable for Workstations, Desktops and Laptops.
           </label>
         </kde_description>
         <gnome>
           <!-- TRANSLATORS: a label for a system role -->
-          <label>Full desktop with GNOME</label>
+          <label>Desktop with GNOME</label>
         </gnome>
         <gnome_description>
-	  <label>Complete graphical system with GNOME as desktop environment. Suitable for Workstations, Desktops and Laptops.
+	  <label>Graphical system with GNOME as desktop environment and additional set of software. Suitable for Workstations, Desktops and Laptops.
 	  </label>
         </gnome_description>
         <xfce>
           <!-- TRANSLATORS: a label for a system role -->
-          <label>Full desktop with Xfce</label>
+          <label>Desktop with Xfce</label>
         </xfce>
         <xfce_description>
-          <label>Complete graphical system with Xfce as desktop environment. Suitable for Workstations, Desktops and Laptops.
+          <label>Graphical system with Xfce as desktop environment and additional set of software. Suitable for Workstations, Desktops and Laptops.
           </label>
         </xfce_description>
 	<generic_desktop>

--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -605,26 +605,26 @@ configured accordingly to match the use case of the role. &lt;/p&gt;</label>
         </roles_help>
         <kde>
           <!-- TRANSLATORS: a label for a system role -->
-          <label>Desktop with KDE Plasma</label>
+          <label>Full desktop with KDE Plasma</label>
         </kde>
         <kde_description>
-	  <label>Graphical system with KDE Plasma as desktop environment. Suitable for Workstations, Desktops and Laptops.
+	  <label>Complete graphical system with KDE Plasma as desktop environment. Suitable for Workstations, Desktops and Laptops.
           </label>
         </kde_description>
         <gnome>
           <!-- TRANSLATORS: a label for a system role -->
-          <label>Desktop with GNOME</label>
+          <label>Full desktop with GNOME</label>
         </gnome>
         <gnome_description>
-	  <label>Graphical system with GNOME as desktop environment. Suitable for Workstations, Desktops and Laptops.
+	  <label>Complete graphical system with GNOME as desktop environment. Suitable for Workstations, Desktops and Laptops.
 	  </label>
         </gnome_description>
         <xfce>
           <!-- TRANSLATORS: a label for a system role -->
-          <label>Desktop with Xfce</label>
+          <label>Full desktop with Xfce</label>
         </xfce>
         <xfce_description>
-          <label>Graphical system with Xfce as desktop environment. Suitable for Workstations, Desktops and Laptops.
+          <label>Complete graphical system with Xfce as desktop environment. Suitable for Workstations, Desktops and Laptops.
           </label>
         </xfce_description>
 	<generic_desktop>


### PR DESCRIPTION
After I came across several opinions that the default installation is "overloaded", I think it is necessary to change the name and description of the graphical system roles.

- first of all, these sets are really **complete**.
- for a beginner who does not want to install something after installation, but wants to "_just work_", these changes will only emphasize his choice.
- for more experienced who do not want an "_overloaded_" desktop, this change will allow his to pay attention to the "Generic Desktop" item and make it clear that he can either from scratch set up your environment, or select the full set and remove the unnecessary ones from there. He may still not notice the ability to configure a set of packages before installation, however, this change will give him an understanding of what awaits him after installation.