### PR TITLE
LegacyX86 port: enable non-oss repository

### DIFF
--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jan  4 11:50:47 UTC 2023 - Dominique Leuenberger <dimstar@opensuse.org>
+
+- LegacyX86: unlike other ports, i586 does have a valid non-oss
+  repo. Do not filter it out (related to boo#1206406).
+- 20230104
+
+-------------------------------------------------------------------
 Mon Dec 12 13:35:16 UTC 2022 - Dominique Leuenberger <dimstar@opensuse.org>
 
 - Define i586 as an external port: openSUSE:Factory is giving up on

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        20221212
+Version:        20230104
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT
@@ -173,9 +173,11 @@ install -m 644 control/${CONTROL_FILE} $RPM_BUILD_ROOT%{?skelcdpath}/CD1/control
     # Update external link
     sed -i -e "s,https://download.opensuse.org/YaST/Repos/openSUSE_Factory_Servers.xml,https://download.opensuse.org/YaST/Repos/openSUSE_$ports_arch\_Factory_Servers.xml," %{buildroot}%{?skelcdpath}/CD1/control.xml
     sed -i -e "s,https://download.opensuse.org/YaST/Repos/openSUSE_Leap_,https://download.opensuse.org/YaST/Repos/openSUSE_$ports_arch\_Leap_," %{buildroot}%{?skelcdpath}/CD1/control.xml
-    #we parse out non existing non-oss repo for ports
-    xsltproc -o %{buildroot}%{?skelcdpath}/CD1/control_ports.xml control/nonoss.xsl %{buildroot}%{?skelcdpath}/CD1/control.xml
-    mv %{buildroot}%{?skelcdpath}/CD1/control{_ports,}.xml
+    %ifnarch %ix86
+        #we parse out non existing non-oss repo for ports, except on i586, where nonoss exists
+        xsltproc -o %{buildroot}%{?skelcdpath}/CD1/control_ports.xml control/nonoss.xsl %{buildroot}%{?skelcdpath}/CD1/control.xml
+        mv %{buildroot}%{?skelcdpath}/CD1/control{_ports,}.xml
+    %endif
     xmllint --noout --relaxng %{_datadir}/YaST2/control/control.rng %{buildroot}%{?skelcdpath}/CD1/control.xml
 %endif
 


### PR DESCRIPTION
 LegacyX86: unlike other ports, i586 does have a valid non-oss
  repo. Do not filter it out (related to boo#1206406).
