### PR TITLE
Enable openh264 by default on Tumbleweed

### DIFF
--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -178,7 +178,7 @@ textdomain="control"
             <extra_url>
                 <baseurl>https://codecs.opensuse.org/openh264/openSUSE_Tumbleweed</baseurl>
                 <alias>repo-openh264</alias>
-                <name>openSUSE-Tumbleweed-openh264</name>
+                <name>Open H.264 Codec (openSUSE Leap)</name>
                 <prod_dir>/</prod_dir>
                 <enabled config:type="boolean">true</enabled>
                 <autorefresh config:type="boolean">true</autorefresh>

--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -178,7 +178,7 @@ textdomain="control"
             <extra_url>
                 <baseurl>https://codecs.opensuse.org/openh264/openSUSE_Tumbleweed</baseurl>
                 <alias>repo-openh264</alias>
-                <name>Open H.264 Codec (openSUSE Leap)</name>
+                <name>Open H.264 Codec (openSUSE Tumbleweed)</name>
                 <prod_dir>/</prod_dir>
                 <enabled config:type="boolean">true</enabled>
                 <autorefresh config:type="boolean">true</autorefresh>

--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -174,6 +174,16 @@ textdomain="control"
                 <autorefresh config:type="boolean">true</autorefresh>
                 <priority config:type="integer">99</priority>
             </extra_url>
+            <!-- https://en.opensuse.org/OpenH264 -->
+            <extra_url>
+                <baseurl>https://codecs.opensuse.org/openh264/openSUSE_Tumbleweed</baseurl>
+                <alias>repo-openh264</alias>
+                <name>openSUSE-Tumbleweed-openh264</name>
+                <prod_dir>/</prod_dir>
+                <enabled config:type="boolean">true</enabled>
+                <autorefresh config:type="boolean">true</autorefresh>
+                <priority config:type="integer">99</priority>
+            </extra_url>
         </extra_urls>
 
         <!-- bnc#874116: Handling software proposal during product upgrade -->

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jan  4 11:50:47 UTC 2023 - Lubos Kocman <Lubos.Kocman@suse.com>
+
+- Enable Open H.264 repo by default code-o-o#leap/features/22
+- 20230124
+
+-------------------------------------------------------------------
 Wed Jan  4 11:50:47 UTC 2023 - Dominique Leuenberger <dimstar@opensuse.org>
 
 - LegacyX86: unlike other ports, i586 does have a valid non-oss

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        20230104
+Version:        20230124
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT


### PR DESCRIPTION
* We have now a redistribution agreement with Cisco https://en.opensuse.org/OpenH264#Installation
* Original request https://code.opensuse.org/leap/features/issue/22
