### PR TITLE
Enable openh264 repo by default on Leap 15.4

### DIFF
--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -192,6 +192,15 @@ textdomain="control"
                 <name>Source Repository</name>
                 <enabled config:type="boolean">false</enabled>
             </extra_url>
+            <extra_url>
+                <baseurl>https://codecs.opensuse.org/openh264/openSUSE_Leap</baseurl>
+                <alias>repo-openh264</alias>
+                <name>openSUSE-Leap-openh264</name>
+                <prod_dir>/</prod_dir>
+                <enabled config:type="boolean">true</enabled>
+                <autorefresh config:type="boolean">true</autorefresh>
+                <priority config:type="integer">99</priority>
+            </extra_url>
         </extra_urls>
 
         <!-- bnc#874116: Handling software proposal during product upgrade -->

--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -195,7 +195,7 @@ textdomain="control"
             <extra_url>
                 <baseurl>https://codecs.opensuse.org/openh264/openSUSE_Leap</baseurl>
                 <alias>repo-openh264</alias>
-                <name>openSUSE-Leap-openh264</name>
+                <name>Open H.264 Codec (openSUSE Leap)</name>
                 <prod_dir>/</prod_dir>
                 <enabled config:type="boolean">true</enabled>
                 <autorefresh config:type="boolean">true</autorefresh>


### PR DESCRIPTION
- We have now a redistribution agreement with Cisco https://en.opensuse.org/OpenH264#Installation
- Original request https://code.opensuse.org/leap/features/issue/22