### PR TITLE
openh264: bump for 15.4

### DIFF
--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,3 +1,10 @@
+Tue Jan 24 10:37:00 UTC 2023 - Lubos Kocman <Lubos.Kocman@suse.com>
+
+- Enable Open H.264 repo by default code-o-o#leap/features/22
+  Resolves jsc#OPENSUSE-46 jsc#SLE-18915
+  fix changelog date
+- 15.4.6
+
 -------------------------------------------------------------------
 Thu Feb  3 08:36:35 UTC 2022 - David Diaz <dgonzalez@suse.com>
 

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        15.4.5
+Version:        15.4.6
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT


### PR DESCRIPTION
Supply missing openh264 changelog entry for 15.4
Resolves jsc#OPENSUSE-46 jsc#SLE-18915