### PR TITLE
openh264: bump for 15.5

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,9 +2,9 @@ require "yast/rake"
 
 Yast::Tasks.configuration do |conf|
   conf.obs_api = "https://api.opensuse.org"
-  conf.obs_target = "openSUSE_Leap_15.4"
-  conf.obs_sr_project = "openSUSE:Leap:15.4"
-  conf.obs_project = "YaST:openSUSE:15.4"
+  conf.obs_target = "openSUSE_Leap_15.5"
+  conf.obs_sr_project = "openSUSE:Leap:15.5"
+  conf.obs_project = "YaST:openSUSE:15.5"
   #lets ignore license check for now
   conf.skip_license_check << /.*/
   conf.exclude_files << /README.md/ #do not pack readme

--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -192,6 +192,15 @@ textdomain="control"
                 <name>Source Repository</name>
                 <enabled config:type="boolean">false</enabled>
             </extra_url>
+            <extra_url>
+                <baseurl>https://codecs.opensuse.org/openh264/openSUSE_Leap</baseurl>
+                <alias>repo-openh264</alias>
+                <name>openSUSE-Leap-openh264</name>
+                <prod_dir>/</prod_dir>
+                <enabled config:type="boolean">true</enabled>
+                <autorefresh config:type="boolean">true</autorefresh>
+                <priority config:type="integer">99</priority>
+            </extra_url>
         </extra_urls>
 
         <!-- bnc#874116: Handling software proposal during product upgrade -->

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jan 24 10:37:00 UTC 2023 - Lubos Kocman <Lubos.Kocman@suse.com>
+
+- Enable Open H.264 repo by default code-o-o#leap/features/22
+  Resolves jsc#OPENSUSE-46 jsc#SLE-18915
+- 15.5.0
+
+-------------------------------------------------------------------
 Thu Feb  3 08:36:35 UTC 2022 - David Diaz <dgonzalez@suse.com>
 
 - Set a full preemption mode via additional kernel param.

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        15.4.5
+Version:        15.5.0
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT


### PR DESCRIPTION
Supply missing openh264 changelog entry for 15.5
Resolves jsc#OPENSUSE-46 jsc#SLE-18915