### PR TITLE
Drop sound

### DIFF
--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -870,52 +870,6 @@ configured accordingly to match the use case of the role. &lt;/p&gt;</label>
                 <proposal_module>bootloader</proposal_module>
             </proposal_modules>
         </proposal>
-
-        <proposal>
-            <label>Network Configuration</label>
-            <name>network</name>
-            <stage>continue,normal</stage>
-            <unique_id>network_continue</unique_id>
-            <enable_skip>yes</enable_skip>
-            <proposal_modules config:type="list">
-                <proposal_module>
-                    <name>lan</name>
-                    <presentation_order>20</presentation_order>
-                </proposal_module>
-                <proposal_module>
-                    <name>general</name>
-                    <presentation_order>5</presentation_order>
-                </proposal_module>
-                <proposal_module>
-                    <name>isdn</name>
-                    <presentation_order>40</presentation_order>
-                </proposal_module>
-                <proposal_module>
-                    <name>remote</name>
-                    <presentation_order>60</presentation_order>
-                </proposal_module>
-                <proposal_module>
-                    <name>firewall</name>
-                    <presentation_order>10</presentation_order>
-                </proposal_module>
-                <proposal_module>
-                    <name>proxy</name>
-                    <presentation_order>70</presentation_order>
-                </proposal_module>
-            </proposal_modules>
-        </proposal>
-
-        <proposal>
-            <label>Hardware Configuration</label>
-            <name>hardware</name>
-            <stage>continue</stage>
-            <unique_id>hardware_continue</unique_id>
-            <enable_skip>yes</enable_skip>
-            <proposal_modules config:type="list">
-                <proposal_module>printer</proposal_module>
-                <proposal_module>sound</proposal_module>
-            </proposal_modules>
-        </proposal>
     </proposals>
 
     <workflows config:type="list">

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jan 25 09:44:50 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
+
+- drop unused proposals definition ( related to drop of yast2-sound
+  bsc#1206903)
+- 20230125
+
+-------------------------------------------------------------------
 Tue Jan 24 10:37:00 UTC 2023 - Lubos Kocman <Lubos.Kocman@suse.com>
 
 - Enable Open H.264 repo by default code-o-o#leap/features/22

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        20230124
+Version:        20230125
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT


### PR DESCRIPTION
Remove from TW no longer used proposals definition. It contain also sound proposal and yast2-sound is going to drop. BTW in network proposal there was also some already dropped clients.

