### PR TITLE
Use http:// for openh264

### DIFF
--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -176,7 +176,7 @@ textdomain="control"
             </extra_url>
             <!-- https://en.opensuse.org/OpenH264 -->
             <extra_url>
-                <baseurl>https://codecs.opensuse.org/openh264/openSUSE_Tumbleweed</baseurl>
+                <baseurl>http://codecs.opensuse.org/openh264/openSUSE_Tumbleweed</baseurl>
                 <alias>repo-openh264</alias>
                 <name>Open H.264 Codec (openSUSE Tumbleweed)</name>
                 <prod_dir>/</prod_dir>

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Jan 26 10:24:00 UTC 2023 - Lubos Kocman <Lubos.Kocman@suse.com>
+
+- Use http:// for openh264 as the redirectiont target
+  does not support https:// (Resolves boo#1207567).
+
+- 20230126
+
+-------------------------------------------------------------------
 Wed Jan 25 09:44:50 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
 
 - drop unused proposals definition ( related to drop of yast2-sound

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        20230125
+Version:        20230126
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT


### PR DESCRIPTION
- Redicretion target does not support https:// (Resolves boo#1207567).
- Resolves boo#1207567
