### PR TITLE
Leap 15.5: use http for openh264 and bump to 15.5

### DIFF
--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -107,7 +107,7 @@ textdomain="control"
         <online_repos_preselected config:type="boolean">false</online_repos_preselected>
 
         <!-- FATE #300898, List of external sources accesible during the installation time -->
-        <external_sources_link>https://download.opensuse.org/YaST/Repos/openSUSE_Leap_15.3_Servers.xml</external_sources_link>
+        <external_sources_link>https://download.opensuse.org/YaST/Repos/openSUSE_Leap_15.5_Servers.xml</external_sources_link>
 
         <dropped_packages/>
         <extra_urls config:type="list">
@@ -250,7 +250,7 @@ textdomain="control"
 	        <!-- Remove this entry when bsc#1177443 has been fixed -->
                 <product_upgrade>
                     <from>openSUSE Leap</from>
-                    <to>openSUSE Leap 15.3</to>
+                    <to>openSUSE Leap 15.5</to>
                     <compatible_vendors config:type="list">
                       <compatible_vendor>openSUSE</compatible_vendor>
                       <compatible_vendor>SUSE LLC</compatible_vendor>

--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -193,7 +193,7 @@ textdomain="control"
                 <enabled config:type="boolean">false</enabled>
             </extra_url>
             <extra_url>
-                <baseurl>https://codecs.opensuse.org/openh264/openSUSE_Leap</baseurl>
+                <baseurl>http://codecs.opensuse.org/openh264/openSUSE_Leap</baseurl>
                 <alias>repo-openh264</alias>
                 <name>Open H.264 Codec (openSUSE Leap)</name>
                 <prod_dir>/</prod_dir>

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -3,8 +3,9 @@ Thu Jan 26 10:24:00 UTC 2023 - Lubos Kocman <Lubos.Kocman@suse.com>
 
 - Use http:// for openh264 as the redirectiont target
   does not support https:// (Resolves boo#1207567).
+- Bump external sources and migrate-to to 15.5
 
-- 15.4.7
+- 15.5.1
 
 -------------------------------------------------------------------
 Mon Jan 23 16:13:13 UTC 2023 - Ladislav Slezák <lslezak@suse.com>

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Jan 26 10:24:00 UTC 2023 - Lubos Kocman <Lubos.Kocman@suse.com>
+
+- Use http:// for openh264 as the redirectiont target
+  does not support https:// (Resolves boo#1207567).
+
+- 15.4.7
+
+-------------------------------------------------------------------
 Mon Jan 23 16:13:13 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
 
 - Adapt the package for openSUSE Leap 15.5 (bsc#1207424)

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        15.5.0
+Version:        15.5.1
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT


### PR DESCRIPTION
 - Use http:// for openh264 as the redirectiont target
   does not support https:// (Resolves boo#1207567).
- Bump external sources and migrate-to to 15.5