### PR TITLE
xsltproc tool is still needed for building on some architectures

### DIFF
--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri May 12 08:50:48 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
+
+- Fix up for the previous update: xsltproc tool is still needed
+  for building on some architectures
+- 20230512.1
+
+-------------------------------------------------------------------
 Fri May 12 07:45:59 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
 
 - Drop the *-promo subpackage (not used anymore and we would have

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        20230512
+Version:        20230512.1
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT
@@ -36,6 +36,8 @@ Url:            https://github.com/yast/skelcd-control-openSUSE
 Source:         skelcd-control-openSUSE-%{version}.tar.bz2
 # xmllint
 BuildRequires:  libxml2-tools
+# xsltproc
+BuildRequires:  libxslt-tools
 # Added 'lsm' section (jsc#SLE-22069)
 BuildRequires:  yast2-installation-control >= 4.4.7
 ######################################################################


### PR DESCRIPTION
- Fix up for the previous update
- Fixes build on ARM: https://build.opensuse.org/package/live_build_log/YaST:Head/skelcd-control-openSUSE/openSUSE_Factory/aarch64


