### PR TITLE
Imported the fix by Yuchen Lin from OBS to Git

### DIFF
--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -107,7 +107,8 @@ textdomain="control"
         <online_repos_preselected config:type="boolean">false</online_repos_preselected>
 
         <!-- FATE #300898, List of external sources accesible during the installation time -->
-        <external_sources_link>https://download.opensuse.org/YaST/Repos/openSUSE_Leap_15.5_Servers.xml</external_sources_link>
+        <!-- the file for 15.5 does not exist, but the 15.3 file uses $releasever so it can be reused -->
+        <external_sources_link>https://download.opensuse.org/YaST/Repos/openSUSE_Leap_15.3_Servers.xml</external_sources_link>
 
         <dropped_packages/>
         <extra_urls config:type="list">
@@ -193,13 +194,10 @@ textdomain="control"
                 <enabled config:type="boolean">false</enabled>
             </extra_url>
             <extra_url>
-                <baseurl>http://codecs.opensuse.org/openh264/openSUSE_Leap</baseurl>
+                <baseurl>http://codecs.opensuse.org/openh264/openSUSE_Leap/</baseurl>
                 <alias>repo-openh264</alias>
                 <name>Open H.264 Codec (openSUSE Leap)</name>
-                <prod_dir>/</prod_dir>
                 <enabled config:type="boolean">true</enabled>
-                <autorefresh config:type="boolean">true</autorefresh>
-                <priority config:type="integer">99</priority>
             </extra_url>
         </extra_urls>
 

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri May 12 13:55:53 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
+
+- Imported the fix by Yuchen Lin from OBS to Git
+- 15.5.4
+
+-------------------------------------------------------------------
 Fri May 12 08:59:41 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
 
 - Fix up for the previous update: xsltproc tool is still needed
@@ -11,6 +17,14 @@ Fri May 12 07:45:59 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
 - Drop the *-promo subpackage (not used anymore, related to
   bsc#1211319)
 - 15.5.2
+
+-------------------------------------------------------------------
+Sat Mar  4 10:00:23 UTC 2023 - Yuchen Lin <mlin+factory@suse.de>
+
+- Fix openh264 repo url
+  * Add fix_openh264_format.patch
+- Change the file of external_sources_link back to openSUSE_Leap_15.3_Servers.xml
+  * the filename is not right, but the url noted in the file uses $releasever
 
 -------------------------------------------------------------------
 Thu Jan 26 10:24:00 UTC 2023 - Lubos Kocman <Lubos.Kocman@suse.com>

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        15.5.3
+Version:        15.5.4
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT


### PR DESCRIPTION
- It turned out that the package was patched directly in OBS and without changing the code in Git
- See https://build.opensuse.org/package/view_file/openSUSE:Leap:15.5/skelcd-control-openSUSE/fix_openh264_format.patch?expand=1
- Include the fix directly in the Git repository
- 15.5.4
