### PR TITLE
Updating the change log

### DIFF
--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -2,6 +2,8 @@
 Fri May 12 13:55:53 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
 
 - Imported the fix by Yuchen Lin from OBS to Git
+  (the fix_openh264_format.patch has been included upstream,
+  removing the patch from OBS)
 - 15.5.4
 
 -------------------------------------------------------------------


### PR DESCRIPTION
- The SR for the previous patch was declined because it does not mention removal of the `fix_openh264_format.patch` in the changes
- See https://build.opensuse.org/request/show/1086785
- See the previous PR #277 