### PR TITLE
Adapted to Leap 15.6

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,9 +2,9 @@ require "yast/rake"
 
 Yast::Tasks.configuration do |conf|
   conf.obs_api = "https://api.opensuse.org"
-  conf.obs_target = "openSUSE_Leap_15.5"
-  conf.obs_sr_project = "openSUSE:Leap:15.5"
-  conf.obs_project = "YaST:openSUSE:15.5"
+  conf.obs_target = "openSUSE_Leap_15.6"
+  conf.obs_sr_project = "openSUSE:Leap:15.6"
+  conf.obs_project = "YaST:openSUSE:15.6"
   #lets ignore license check for now
   conf.skip_license_check << /.*/
   conf.exclude_files << /README.md/ #do not pack readme

--- a/control/control.openSUSE.xml
+++ b/control/control.openSUSE.xml
@@ -107,7 +107,7 @@ textdomain="control"
         <online_repos_preselected config:type="boolean">false</online_repos_preselected>
 
         <!-- FATE #300898, List of external sources accesible during the installation time -->
-        <!-- the file for 15.5 does not exist, but the 15.3 file uses $releasever so it can be reused -->
+        <!-- the file for 15.6 does not exist, but the 15.3 file uses $releasever so it can be reused -->
         <external_sources_link>https://download.opensuse.org/YaST/Repos/openSUSE_Leap_15.3_Servers.xml</external_sources_link>
 
         <dropped_packages/>
@@ -248,7 +248,7 @@ textdomain="control"
 	        <!-- Remove this entry when bsc#1177443 has been fixed -->
                 <product_upgrade>
                     <from>openSUSE Leap</from>
-                    <to>openSUSE Leap 15.5</to>
+                    <to>openSUSE Leap 15.6</to>
                     <compatible_vendors config:type="list">
                       <compatible_vendor>openSUSE</compatible_vendor>
                       <compatible_vendor>SUSE LLC</compatible_vendor>

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Sep 20 12:31:53 UTC 2023 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Adapted for openSUSE Leap 15.6 (bsc#1215432)
+- 15.6.0
+
+-------------------------------------------------------------------
 Fri May 12 13:55:53 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
 
 - Imported the fix by Yuchen Lin from OBS to Git

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        15.5.4
+Version:        15.6.0
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1215432


## Trello

https://trello.com/c/8SW384Bo/


## Problem

No specific control file for Leap 15.6 yet.


## Fix

- Created a new branch _openSUSE-15_6_ based on _openSUSE-15_5_.
- Adapted the toplevel _Rakefile_ to use the _openSUSE:Leap:15.6_ OBS target.
- Adapted the control.xml file to the new distro release.