### PR TITLE
Restore label for system roles

### DIFF
--- a/control/control.xml
+++ b/control/control.xml
@@ -800,6 +800,7 @@ configured accordingly to match the use case of the role. &lt;/p&gt;</label>
                     <name>download_release_notes</name>
                 </module>
                 <module>
+                    <label>System Role</label>
                     <name>system_role</name>
                 </module>
                 <module>

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jul 31 10:26:00 UTC 2024 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Bring back the label "System Role" to the left pane (bsc#1228171)
+- 20240731
+
+-------------------------------------------------------------------
 Thu May 16 08:46:56 UTC 2024 - Ludwig Nussel <lnussel@suse.com>
 
 - Enable LUKS2 and PBKDF2 by default for compat with grub (boo#1185291)

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        20240516
+Version:        20240731
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT


### PR DESCRIPTION
Back at 2018, a pull request was merged to (among other things) start using the YaST client `system_role` instead of the previous client `desktop_role`. #139.

That pull request [removed the label for the installation step](https://github.com/yast/skelcd-control-openSUSE/commit/527120f487ba01fb9c7cb89c27fc5a75f9a9e23b#diff-6fd657077cfb5e0ff393b2a9cc86746e10cf5baa24abbf8c3a48e4ed7cb7030cL1015). I doubt that was intentional.

This reintroduces the label, hopefully fixing [bsc#1228171](https://bugzilla.suse.com/show_bug.cgi?id=1228171).


