### PR TITLE
Select SELinux as default MAC in enforcing mode

### DIFF
--- a/control/control.xml
+++ b/control/control.xml
@@ -80,14 +80,13 @@ textdomain="control"
         <enable_kdump config:type="boolean">true</enable_kdump>
 
         <lsm>
-          <select>apparmor</select>
+          <select>selinux</select>
           <apparmor>
             <patterns>apparmor</patterns>
             <selectable config:type="boolean">true</selectable>
           </apparmor>
-          <!-- Set SELinux permissive mode by default, https://github.com/yast/yast-installation/pull/906#issuecomment-784238549 -->
           <selinux>
-            <mode>permissive</mode>
+            <mode>enforcing</mode>
             <configurable config:type="boolean">true</configurable>
             <selectable config:type="boolean">true</selectable>
             <patterns>selinux</patterns>

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Sep  3 08:30:52 UTC 2024 - Cathy Hu <cathy.hu@suse.com>
+
+- Set SELinux as default LSM in enforcing mode instead of AppArmor (bsc#1230118)
+
+-------------------------------------------------------------------
 Wed Jul 31 10:26:00 UTC 2024 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Bring back the label "System Role" to the left pane (bsc#1228171)

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        20240731
+Version:        20240902
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT


### PR DESCRIPTION
as discussed with @DimStar77 we want to change the default LSM in tumbleweed to selinux in enforcing mode
see also email "RFC: SELinux as default MAC system on new Tumbleweed installations"

Tested using tumbleweed live iso and copying the control.xml into /etc/YaST2/control.xml and installing the system via installer

Please let me know if something is missing or you would like me to do additional testing