### PR TITLE
GNOME: no longer mark X11 pattern to be installed by default

### DIFF
--- a/control/control.xml
+++ b/control/control.xml
@@ -398,7 +398,7 @@ textdomain="control"
       <system_role>
         <id>gnome</id>
         <software>
-          <default_patterns>gnome x11 base enhanced_base x11_yast yast2_basis</default_patterns>
+          <default_patterns>gnome base enhanced_base x11_yast yast2_basis</default_patterns>
         </software>
         <order config:type="integer">200</order>
       </system_role>

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Mon Sep 29 10:17:29 UTC 2025 - Dominique Leuenberger <dimstar@opensuse.org>
+
+- GNOME: no longer mark X11 pattern to be installed by default
+  With the switch to GNOME 49, there is no longer an X-session available
+  and as a consequence, there is no benefit of us requiring the x11
+  patterns when installng gnome
+- 20250929
+
+-------------------------------------------------------------------
 Fri Jun 20 10:03:35 UTC 2025 - Stefan Schubert <schubi@suse.de>
 
 - Using systemd_fde in partition proposal (jsc#PED-10703).

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        20250620
+Version:        20250929
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT


### PR DESCRIPTION
With the switch to GNOME 49, there is no longer an X-session available
and as a consequence, there is no benefit of us requiring the x11
patterns when installng gnome

Note for the pull request authors:

The `master` branch is intended for the openSUSE Tumbleweed only,
if you want to have the same change in the openSUSE Leap then backport
it to the respective `openSUSE-X_Y` branch.

