### PR TITLE
Enable non-oss on aarch64 and armv6/7

### DIFF
--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Apr 10 09:37:23 UTC 2026 - Guillaume GARDET <guillaume.gardet@opensuse.org>
+
+- Enable non-oss on aarch64 and armv6/7
+  gh#yast/skelcd-control-openSUSE#291
+
+-------------------------------------------------------------------
 Thu Feb 26 08:50:52 UTC 2026 - Stefan Schubert <schubi@suse.de>
 
 - Set default bootloader to systemd-boot (jsc#PED-1906).

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -166,8 +166,8 @@ install -m 644 control/${CONTROL_FILE} $RPM_BUILD_ROOT%{?skelcdpath}/CD1/control
     # Update external link
     sed -i -e "s,https://download.opensuse.org/YaST/Repos/openSUSE_Factory_Servers.xml,https://download.opensuse.org/YaST/Repos/openSUSE_$ports_arch\_Factory_Servers.xml," %{buildroot}%{?skelcdpath}/CD1/control.xml
     sed -i -e "s,https://download.opensuse.org/YaST/Repos/openSUSE_Leap_,https://download.opensuse.org/YaST/Repos/openSUSE_$ports_arch\_Leap_," %{buildroot}%{?skelcdpath}/CD1/control.xml
-    %ifnarch %ix86
-        #we parse out non existing non-oss repo for ports, except on i586, where nonoss exists
+    %ifnarch %ix86 aarch64 %{arm}
+        #we parse out non existing non-oss repo for ports, except on i586, aarch64, armv6/7 where nonoss exists
         xsltproc -o %{buildroot}%{?skelcdpath}/CD1/control_ports.xml control/nonoss.xsl %{buildroot}%{?skelcdpath}/CD1/control.xml
         mv %{buildroot}%{?skelcdpath}/CD1/control{_ports,}.xml
     %endif


### PR DESCRIPTION
Available at :
* https://download.opensuse.org/ports/aarch64/tumbleweed/repo/non-oss/
* https://download.opensuse.org/ports/armv7hl/tumbleweed/repo/non-oss/
* https://download.opensuse.org/ports/armv6hl/tumbleweed/repo/non-oss/