### PR TITLE
Set default bootloader to systemd-boot

### DIFF
--- a/control/control.xml
+++ b/control/control.xml
@@ -28,7 +28,7 @@ textdomain="control"
         <enable_register_hwdata config:type="boolean">true</enable_register_hwdata>
         <enable_register_optional config:type="boolean">true</enable_register_optional>
         <enable_systemd_boot config:type="boolean">true</enable_systemd_boot>
-        <preferred_bootloader>grub2-bls</preferred_bootloader>
+        <preferred_bootloader>systemd-boot</preferred_bootloader>
         <display_register_forcereg config:type="boolean">true</display_register_forcereg>
         <disable_register_w3m config:type="boolean">true</disable_register_w3m>
         <register_monthly config:type="boolean">false</register_monthly>

--- a/package/skelcd-control-openSUSE.changes
+++ b/package/skelcd-control-openSUSE.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Feb 26 08:50:52 UTC 2026 - Stefan Schubert <schubi@suse.de>
+
+- Set default bootloader to systemd-boot (jsc#PED-1906).
+- 20260226
+
+-------------------------------------------------------------------
 Thu Nov  6 16:42:15 UTC 2025 - Dominique Leuenberger <dimstar@opensuse.org>
 
 - GNOME: Pre-configure graphical.target: don't let yast guess the

--- a/package/skelcd-control-openSUSE.spec
+++ b/package/skelcd-control-openSUSE.spec
@@ -27,7 +27,7 @@
 #
 ######################################################################
 Name:           skelcd-control-openSUSE
-Version:        20250929
+Version:        20260226
 Release:        0
 Summary:        The openSUSE Installation Control file
 License:        MIT


### PR DESCRIPTION
Note for the pull request authors:

The `master` branch is intended for the openSUSE Tumbleweed only,
if you want to have the same change in the openSUSE Leap then backport
it to the respective `openSUSE-X_Y` branch.

